### PR TITLE
[ #7 ] 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,47 +1,49 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.4'
-	id 'io.spring.dependency-management' version '1.1.3'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.4'
+    id 'io.spring.dependency-management' version '1.1.3'
 }
 
 // -plain.jar 파일이 생성되지 않게 하기 위해 설정
 jar {
-	enabled = false
+    enabled = false
 }
 
 group = 'inha.capstone'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	// Database Mysql
-	runtimeOnly 'mysql:mysql-connector-java:8.0.32'
+    // Database Mysql
+    runtimeOnly 'mysql:mysql-connector-java:8.0.32'
 
-	// Spring Security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	testImplementation 'org.springframework.security:spring-security-test'
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/inha/capstone/fooda/FoodaApplication.java
+++ b/src/main/java/inha/capstone/fooda/FoodaApplication.java
@@ -2,12 +2,14 @@ package inha.capstone.fooda;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class FoodaApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(FoodaApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(FoodaApplication.class, args);
+    }
 
 }

--- a/src/main/java/inha/capstone/fooda/config/SwaggerConfig.java
+++ b/src/main/java/inha/capstone/fooda/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package inha.capstone.fooda.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI pixelWaveAPI(@Value("${pix-el-wave.application.version}") String appVersion) {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("pix-el-wave API")
+                                .description("pix-el-wave API 명세서")
+                                .version(appVersion)
+                )
+                .externalDocs(
+                        new ExternalDocumentation()
+                                .description("Team pix-el-wave GitHub Organization")
+                                .url("https://github.com/pix-el-wave")
+                )
+                .components(
+                        new Components()
+                                .addSecuritySchemes(
+                                        "access-token",
+                                        new SecurityScheme()
+                                                .type(SecurityScheme.Type.HTTP)
+                                                .scheme("bearer")
+                                                .bearerFormat("JWT")
+                                )
+                );
+    }
+}

--- a/src/main/java/inha/capstone/fooda/config/WebSecurityConfig.java
+++ b/src/main/java/inha/capstone/fooda/config/WebSecurityConfig.java
@@ -1,0 +1,45 @@
+package inha.capstone.fooda.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+
+import java.util.Collections;
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(securedEnabled = true) // @Secured 사용
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    @Bean
+    protected SecurityFilterChain configure(HttpSecurity http) throws Exception {
+        http.cors(c -> c.configurationSource(
+                request -> {
+                    CorsConfiguration config = new CorsConfiguration();
+                    config.setAllowedOriginPatterns(Collections.singletonList("*"));
+                    config.setAllowedMethods(Collections.singletonList("*"));
+                    config.setAllowCredentials(true);
+                    config.setAllowedHeaders(Collections.singletonList("*"));
+                    config.setExposedHeaders(List.of("Authorization"));
+                    config.setMaxAge(3600L);
+                    return config;
+                }));
+        http.csrf(AbstractHttpConfigurer::disable);
+        http.sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        http.authorizeHttpRequests(c -> c.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .requestMatchers("/**").permitAll()
+                .anyRequest().permitAll());
+        http.formLogin(AbstractHttpConfigurer::disable);
+        return http.build();
+    }
+}

--- a/src/main/java/inha/capstone/fooda/config/WebSecurityConfig.java
+++ b/src/main/java/inha/capstone/fooda/config/WebSecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 
@@ -41,5 +43,10 @@ public class WebSecurityConfig {
                 .anyRequest().permitAll());
         http.formLogin(AbstractHttpConfigurer::disable);
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/common/exception/BadRequestException.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/exception/BadRequestException.java
@@ -1,0 +1,14 @@
+package inha.capstone.fooda.domain.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends CustomException {
+
+    public BadRequestException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+
+    public BadRequestException(String optionalMessage) {
+        super(HttpStatus.BAD_REQUEST, optionalMessage);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/common/exception/ConflictException.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/exception/ConflictException.java
@@ -1,0 +1,14 @@
+package inha.capstone.fooda.domain.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ConflictException extends CustomException {
+
+    public ConflictException() {
+        super(HttpStatus.CONFLICT);
+    }
+
+    public ConflictException(String optionalMessage) {
+        super(HttpStatus.CONFLICT, optionalMessage);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/common/exception/CustomException.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/exception/CustomException.java
@@ -1,0 +1,26 @@
+package inha.capstone.fooda.domain.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final int errorCode;
+    private final String errorMessage;
+
+    public CustomException(HttpStatus httpStatus) {
+        ExceptionType exceptionType = ExceptionType.from(this.getClass());
+        this.httpStatus = httpStatus;
+        this.errorCode = exceptionType.getErrorCode();
+        this.errorMessage = exceptionType.getErrorMessage();
+    }
+
+    public CustomException(HttpStatus httpStatus, String optionalMessage) {
+        ExceptionType exceptionType = ExceptionType.from(this.getClass());
+        this.httpStatus = httpStatus;
+        this.errorCode = exceptionType.getErrorCode();
+        this.errorMessage = exceptionType.getErrorMessage() + " " + optionalMessage;
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/common/exception/ExceptionType.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/exception/ExceptionType.java
@@ -1,0 +1,50 @@
+package inha.capstone.fooda.domain.common.exception;
+
+import inha.capstone.fooda.domain.member.exception.UsernameDuplicateException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * [ Error code 규약 ]
+ * Auth: 1XXX
+ * Member : 2XXX
+ */
+
+@AllArgsConstructor
+@Getter
+public enum ExceptionType {
+
+    // Common
+    UNHANDLED_EXCEPTION(0, "알 수 없는 서버 에러가 발생했습니다.", null),
+    BAD_REQUEST_EXCEPTION(1, "요청 데이터가 잘못되었습니다.", null),
+    ACCESS_DENIED_EXCEPTION(2, "권한이 유효하지 않습니다.", null),
+    AUTHENTICATION_EXCEPTION(3, "인증 과정에서 문제가 발생했습니다.", null),
+
+    // Auth
+    USERNAME_DUPLICATE_EXEPTION(1000, "아이디(유저네임)이 중복됩니다.", UsernameDuplicateException.class);
+
+    private final int errorCode;
+    private final String errorMessage;
+    private final Class<? extends Exception> type;
+
+    public static ExceptionType from(Class<? extends CustomException> classType) {
+        return findExceptionType(classType, UNHANDLED_EXCEPTION);
+    }
+
+    public static ExceptionType fromByAuthenticationFailed(Class<? extends Exception> classType) {
+        return findExceptionType(classType, AUTHENTICATION_EXCEPTION);
+    }
+
+    private static ExceptionType findExceptionType(
+            Class<? extends Exception> classType,
+            ExceptionType defaultExceptionType
+    ) {
+        return Arrays.stream(values())
+                .filter(it -> Objects.nonNull(it.type) && it.type.equals(classType))
+                .findFirst()
+                .orElse(defaultExceptionType);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/common/exception/ForbiddenException.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/exception/ForbiddenException.java
@@ -1,0 +1,14 @@
+package inha.capstone.fooda.domain.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends CustomException {
+
+    public ForbiddenException() {
+        super(HttpStatus.FORBIDDEN);
+    }
+
+    public ForbiddenException(String optionalMessage) {
+        super(HttpStatus.FORBIDDEN, optionalMessage);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/common/exception/NotFoundException.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/exception/NotFoundException.java
@@ -1,0 +1,14 @@
+package inha.capstone.fooda.domain.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends CustomException {
+
+    public NotFoundException() {
+        super(HttpStatus.NOT_FOUND);
+    }
+
+    public NotFoundException(String optionalMessage) {
+        super(HttpStatus.NOT_FOUND, optionalMessage);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/common/exception/UnauthorizedException.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/exception/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package inha.capstone.fooda.domain.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends CustomException {
+
+    public UnauthorizedException() {
+        super(HttpStatus.UNAUTHORIZED);
+    }
+
+    public UnauthorizedException(String optionalMessage) {
+        super(HttpStatus.UNAUTHORIZED, optionalMessage);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/common/response/BaseResponse.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/response/BaseResponse.java
@@ -1,0 +1,13 @@
+package inha.capstone.fooda.domain.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class BaseResponse {
+
+    @Schema(example = "true", description = "요청 처리 성공 시 true, 실패 시 false")
+    private boolean isSuccess;
+}

--- a/src/main/java/inha/capstone/fooda/domain/common/response/DataResponse.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/response/DataResponse.java
@@ -1,0 +1,16 @@
+package inha.capstone.fooda.domain.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class DataResponse<T> extends BaseResponse {
+
+    @Schema(description = "응답 데이터")
+    private T data;
+
+    public DataResponse(T data) {
+        super(true);
+        this.data = data;
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/common/response/ErrorResponse.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/response/ErrorResponse.java
@@ -1,0 +1,20 @@
+package inha.capstone.fooda.domain.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse extends BaseResponse {
+
+    @Schema(example = "0", description = "팀에서 정한 내부적인 error code")
+    private int errorCode;
+
+    @Schema(example = "Error message", description = "에러 상황에 대한 설명")
+    private String errorMessage;
+
+    public ErrorResponse(int errorCode, String errorMessage) {
+        super(false);
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/common/response/GlobalExceptionHandler.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/response/GlobalExceptionHandler.java
@@ -1,0 +1,62 @@
+package inha.capstone.fooda.domain.common.response;
+
+import inha.capstone.fooda.domain.common.exception.CustomException;
+import inha.capstone.fooda.domain.common.exception.ExceptionType;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> customExceptionHandle(CustomException e) {
+        log.error("CustomException: {}", String.valueOf(e));
+
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(new ErrorResponse(e.getErrorCode(), e.getErrorMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandle(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException: {}", String.valueOf(e));
+
+        int errorCode = ExceptionType.BAD_REQUEST_EXCEPTION.getErrorCode();
+        String errorMessage = ExceptionType.BAD_REQUEST_EXCEPTION.getErrorMessage() + " " + e.getAllErrors().get(0).getDefaultMessage();
+
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse(errorCode, errorMessage));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> constraintViolationExceptionHandle(ConstraintViolationException e) {
+        log.error("ConstraintViolationException: {}", String.valueOf(e));
+
+        int errorCode = ExceptionType.BAD_REQUEST_EXCEPTION.getErrorCode();
+        String errorMessage = ExceptionType.BAD_REQUEST_EXCEPTION.getErrorMessage() + " " + e.getLocalizedMessage();
+
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse(errorCode, errorMessage));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> exceptionHandle(Exception e) {
+        StackTraceElement[] stackTrace = e.getStackTrace();
+        log.error("UnHandled Exception: {} info=" + "{}:{}:{}", e,
+                stackTrace[0].getClassName(), stackTrace[0].getMethodName(), stackTrace[0].getLineNumber());
+
+        int errorCode = ExceptionType.UNHANDLED_EXCEPTION.getErrorCode();
+        String errorMessage = ExceptionType.UNHANDLED_EXCEPTION.getErrorMessage();
+
+        return ResponseEntity
+                .internalServerError()
+                .body(new ErrorResponse(errorCode, errorMessage));
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/controller/AuthController.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/controller/AuthController.java
@@ -1,0 +1,40 @@
+package inha.capstone.fooda.domain.member.controller;
+
+import inha.capstone.fooda.domain.common.response.DataResponse;
+import inha.capstone.fooda.domain.member.dto.PostSignupMemberReqDto;
+import inha.capstone.fooda.domain.member.dto.PostSignupMemberResDto;
+import inha.capstone.fooda.domain.member.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Login & SignUp")
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@RestController
+public class AuthController {
+    private final AuthService authService;
+
+    @Operation(
+            summary = "회원가입 API",
+            description = "<p>회원 정보를 바탕으로 회원 가입을 진행합니다.</p>" +
+                    "<p>회원가입에 성공하면 회원가입된 사용자의 pk 를 응답합니다.</p>"
+    )
+    @PostMapping(value = "/local/new")
+    public ResponseEntity<DataResponse<PostSignupMemberResDto>> signUp(
+            @Validated @RequestBody PostSignupMemberReqDto postSignupMemberReqDto) {
+        Long memberId = authService.signUp(postSignupMemberReqDto.toDto());
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new DataResponse<>(
+                        PostSignupMemberResDto.of(memberId)
+                ));
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/MemberDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/MemberDto.java
@@ -1,0 +1,37 @@
+package inha.capstone.fooda.domain.member.dto;
+
+import inha.capstone.fooda.domain.member.entity.Gender;
+import inha.capstone.fooda.domain.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class MemberDto {
+    private Long id;
+    private String name;
+    private String username;
+    private String password;
+    private Gender gender;
+    private Integer weight;
+    private Integer height;
+    private Integer age;
+
+    public static MemberDto of(String name, String username, String password, Gender gender, Integer weight, Integer height, Integer age) {
+        return new MemberDto(null, name, username, password, gender, weight, height, age);
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .id(getId())
+                .name(getName())
+                .username(getUsername())
+                .password(getPassword())
+                .gender(getGender())
+                .weight(getWeight())
+                .height(getHeight())
+                .age(getAge())
+                .build();
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/MemberDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/MemberDto.java
@@ -5,6 +5,7 @@ import inha.capstone.fooda.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
@@ -12,6 +13,7 @@ public class MemberDto {
     private Long id;
     private String name;
     private String username;
+    @Setter
     private String password;
     private Gender gender;
     private Integer weight;

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/PostSignupMemberReqDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/PostSignupMemberReqDto.java
@@ -1,0 +1,53 @@
+package inha.capstone.fooda.domain.member.dto;
+
+import inha.capstone.fooda.domain.member.entity.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostSignupMemberReqDto {
+    @NotBlank(message = "이름을 입력해주세요.")
+    @Size(min = 2, message = "이름이 너무 짧습니다.")
+    @Schema(example = "홍길동", description = "사용자의 실명")
+    private String name;
+
+    @NotBlank(message = "아이디(닉네임)을 입력해주세요.")
+    @Size(min = 2, message = "아이디가 너무 짧습니다.")
+    @Schema(example = "gildong", description = "사용자의 아이디(닉네임)")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 입력해주세요")
+    @Schema(example = "pwd1234!", description = "비밀번호")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}",
+            message = "비밀번호는 영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상씩 포함된 8자 ~ 20자의 비밀번호여야 합니다.")
+    private String password;
+
+    @NotNull(message = "성별(MALE 또는 FEMALE)을 입력해주세요")
+    @Schema(example = "MALE", description = "성별")
+    private Gender gender;
+
+    @NotNull(message = "몸무게를 입력해주세요")
+    @Schema(example = "60", description = "몸무게")
+    private Integer weight;
+
+    @NotNull(message = "키를 입력해주세요")
+    @Schema(example = "180", description = "키")
+    private Integer height;
+
+    @NotNull(message = "나이를 입력해주세요")
+    @Schema(example = "25", description = "나이")
+    private Integer age;
+
+    public MemberDto toDto() {
+        return MemberDto.of(getName(), getUsername(), getPassword(), getGender(), getWeight(), getHeight(), getAge());
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/PostSignupMemberResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/PostSignupMemberResDto.java
@@ -1,0 +1,15 @@
+package inha.capstone.fooda.domain.member.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class PostSignupMemberResDto {
+    private Long id;
+
+    public static PostSignupMemberResDto of(Long id) {
+        return new PostSignupMemberResDto(id);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/entity/Member.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/entity/Member.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Objects;
 
@@ -50,6 +51,26 @@ public class Member extends BaseEntity {
         this.weight = weight;
         this.height = height;
         this.age = age;
+    }
+
+    /**
+     * password를 암호화한다.
+     *
+     * @param passwordEncoder
+     */
+    public void encodePassword(PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(password);
+    }
+
+    /**
+     * 비밀번호가 일치하는지 확인하는 메소드
+     *
+     * @param passwordEncoder
+     * @param checkPassword
+     * @return 비밀번호가 일치하면 true
+     */
+    public boolean matchPassword(PasswordEncoder passwordEncoder, String checkPassword) {
+        return passwordEncoder.matches(checkPassword, getPassword());
     }
 
     @Override

--- a/src/main/java/inha/capstone/fooda/domain/member/entity/Member.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/entity/Member.java
@@ -40,6 +40,18 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private Integer age;
 
+    @Builder
+    public Member(Long id, String name, String username, String password, Gender gender, Integer weight, Integer height, Integer age) {
+        this.id = id;
+        this.name = name;
+        this.username = username;
+        this.password = password;
+        this.gender = gender;
+        this.weight = weight;
+        this.height = height;
+        this.age = age;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/inha/capstone/fooda/domain/member/exception/UsernameDuplicateException.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/exception/UsernameDuplicateException.java
@@ -1,0 +1,6 @@
+package inha.capstone.fooda.domain.member.exception;
+
+import inha.capstone.fooda.domain.common.exception.ConflictException;
+
+public class UsernameDuplicateException extends ConflictException {
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/exception/UsernameDuplicateException.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/exception/UsernameDuplicateException.java
@@ -3,4 +3,7 @@ package inha.capstone.fooda.domain.member.exception;
 import inha.capstone.fooda.domain.common.exception.ConflictException;
 
 public class UsernameDuplicateException extends ConflictException {
+    public UsernameDuplicateException(String optionalMessage) {
+        super(optionalMessage);
+    }
 }

--- a/src/main/java/inha/capstone/fooda/domain/member/repository/MemberRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package inha.capstone.fooda.domain.member.repository;
+
+import inha.capstone.fooda.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/service/AuthService.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/service/AuthService.java
@@ -1,0 +1,25 @@
+package inha.capstone.fooda.domain.member.service;
+
+import inha.capstone.fooda.domain.member.dto.MemberDto;
+import inha.capstone.fooda.domain.member.entity.Member;
+import inha.capstone.fooda.domain.member.exception.UsernameDuplicateException;
+import inha.capstone.fooda.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class AuthService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long signUp(MemberDto memberDto) {
+        if (memberRepository.existsByUsername(memberDto.getUsername())) {
+            throw new UsernameDuplicateException();
+        }
+        Member savedMember = memberRepository.save(memberDto.toEntity());
+        return savedMember.getId();
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/service/AuthService.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/service/AuthService.java
@@ -5,6 +5,7 @@ import inha.capstone.fooda.domain.member.entity.Member;
 import inha.capstone.fooda.domain.member.exception.UsernameDuplicateException;
 import inha.capstone.fooda.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,13 +14,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public Long signUp(MemberDto memberDto) {
+        // 아이디(닉네임) 중복 여부 확인
         if (memberRepository.existsByUsername(memberDto.getUsername())) {
             throw new UsernameDuplicateException();
         }
+
         Member savedMember = memberRepository.save(memberDto.toEntity());
+        savedMember.encodePassword(passwordEncoder); // 비밀번호 암호화
+
         return savedMember.getId();
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/member/service/AuthService.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/service/AuthService.java
@@ -23,8 +23,9 @@ public class AuthService {
             throw new UsernameDuplicateException(memberDto.getUsername() + " 는 이미 존재하는 username 입니다.");
         }
 
+        memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword())); // 비밀번호 암호화
+
         Member savedMember = memberRepository.save(memberDto.toEntity());
-        savedMember.encodePassword(passwordEncoder); // 비밀번호 암호화
 
         return savedMember.getId();
     }

--- a/src/main/java/inha/capstone/fooda/domain/member/service/AuthService.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/service/AuthService.java
@@ -20,7 +20,7 @@ public class AuthService {
     public Long signUp(MemberDto memberDto) {
         // 아이디(닉네임) 중복 여부 확인
         if (memberRepository.existsByUsername(memberDto.getUsername())) {
-            throw new UsernameDuplicateException();
+            throw new UsernameDuplicateException(memberDto.getUsername() + " 는 이미 존재하는 username 입니다.");
         }
 
         Member savedMember = memberRepository.save(memberDto.toEntity());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+pix-el-wave.application.version: v0.0.1
+
 spring:
   profiles:
     active: prod

--- a/src/test/java/inha/capstone/fooda/domain/member/service/AuthServiceTest.java
+++ b/src/test/java/inha/capstone/fooda/domain/member/service/AuthServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class AuthServiceTest {
+  
+}

--- a/src/test/java/inha/capstone/fooda/domain/member/service/AuthServiceTest.java
+++ b/src/test/java/inha/capstone/fooda/domain/member/service/AuthServiceTest.java
@@ -1,4 +1,52 @@
-import static org.junit.jupiter.api.Assertions.*;
+package inha.capstone.fooda.domain.member.service;
+
+import inha.capstone.fooda.domain.member.dto.MemberDto;
+import inha.capstone.fooda.domain.member.entity.Gender;
+import inha.capstone.fooda.domain.member.entity.Member;
+import inha.capstone.fooda.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
-  
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    public void 유저정보가_주어지면_회원가입을_수행한다() {
+        //given
+        MemberDto memberDto = createMemberDto();
+        given(memberRepository.existsByUsername(any(String.class))).willReturn(false);
+        given(memberRepository.save(any(Member.class))).willReturn(createMember());
+
+        //when
+        authService.signUp(memberDto);
+
+        //then
+        then(memberRepository).should().save(any(Member.class));
+    }
+
+    private Member createMember() {
+        Member member = createMemberDto().toEntity();
+        ReflectionTestUtils.setField(member, "id", 1L);
+        return member;
+    }
+
+    private MemberDto createMemberDto() {
+        return MemberDto.of("멤버1", "member1", "pwd1234!", Gender.MALE, 70, 180, 25);
+    }
 }


### PR DESCRIPTION
### 관련 이슈
- #7 

### 작업 사항
- 회원가입 API 구현

### 특이사항
- BaseResponse 설정
- Exception 설정
- Swagger 의존성 추가
- FoodaApplication에서 @EnableJpaAuditing 추가 : BaseEntity의 createdAt null로 설정되는 문제 해결 목적