### PR TITLE
[ #9 ] 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // JWT 토큰
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }

--- a/src/main/java/inha/capstone/fooda/config/SwaggerConfig.java
+++ b/src/main/java/inha/capstone/fooda/config/SwaggerConfig.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -34,6 +35,7 @@ public class SwaggerConfig {
                                                 .scheme("bearer")
                                                 .bearerFormat("JWT")
                                 )
-                );
+                )
+                .addSecurityItem(new SecurityRequirement().addList("access-token"));
     }
 }

--- a/src/main/java/inha/capstone/fooda/config/WebSecurityConfig.java
+++ b/src/main/java/inha/capstone/fooda/config/WebSecurityConfig.java
@@ -1,9 +1,16 @@
 package inha.capstone.fooda.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inha.capstone.fooda.domain.common.exception.ExceptionType;
+import inha.capstone.fooda.domain.common.response.ErrorResponse;
+import inha.capstone.fooda.security.JwtAuthenticationFilter;
+import inha.capstone.fooda.security.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -12,19 +19,29 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
 import java.util.Collections;
 import java.util.List;
 
+@Slf4j
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(securedEnabled = true) // @Secured 사용
 @RequiredArgsConstructor
 public class WebSecurityConfig {
 
+    private static final String[] AUTH_WHITELIST = {
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/actuator/**"
+    };
+    private static final String BASE_URL = "/api";
+
     @Bean
     protected SecurityFilterChain configure(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable);
         http.cors(c -> c.configurationSource(
                 request -> {
                     CorsConfiguration config = new CorsConfiguration();
@@ -36,12 +53,49 @@ public class WebSecurityConfig {
                     config.setMaxAge(3600L);
                     return config;
                 }));
-        http.csrf(AbstractHttpConfigurer::disable);
         http.sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
-        http.authorizeHttpRequests(c -> c.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                .requestMatchers("/**").permitAll()
-                .anyRequest().permitAll());
         http.formLogin(AbstractHttpConfigurer::disable);
+        http.authorizeHttpRequests(c -> c
+                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                .requestMatchers(AUTH_WHITELIST).permitAll()
+                .requestMatchers(BASE_URL + "/auth/local/new").permitAll()
+                .requestMatchers(BASE_URL + "/auth/local").permitAll()
+                .anyRequest().authenticated());
+        http.addFilterBefore(
+                new JwtAuthenticationFilter(jwtTokenProvider),
+                UsernamePasswordAuthenticationFilter.class
+        );
+
+        http.exceptionHandling((exception) -> exception
+                .accessDeniedHandler((request, response, accessDeniedException) -> {
+                    // 권한 문제가 발생했을 때 이 부분을 호출한다.
+                    log.error("SecurityConfig.SecurityFilterChain.accessDeniedHandler() ex={}", String.valueOf(accessDeniedException));
+
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                    response.setCharacterEncoding("utf-8");
+                    response.setContentType("application/json; charset=UTF-8");
+
+                    int errorCode = ExceptionType.ACCESS_DENIED_EXCEPTION.getErrorCode();
+                    String errorMessage = ExceptionType.ACCESS_DENIED_EXCEPTION.getErrorMessage();
+                    ErrorResponse errorResponse = new ErrorResponse(errorCode, errorMessage);
+
+                    response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+                }).authenticationEntryPoint((request, response, authException) -> {
+                    // 인증문제가 발생했을 때 이 부분을 호출한다.
+                    log.error("SecurityConfig.SecurityFilterChain.authenticationEntryPoint() ex={}", String.valueOf(authException));
+
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.setCharacterEncoding("utf-8");
+                    response.setContentType("application/json; charset=UTF-8");
+
+                    int errorCode = ExceptionType.AUTHENTICATION_EXCEPTION.getErrorCode();
+                    String errorMessage = ExceptionType.AUTHENTICATION_EXCEPTION.getErrorMessage();
+                    ErrorResponse errorResponse = new ErrorResponse(errorCode, errorMessage);
+
+                    response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+                }));
+
+
         return http.build();
     }
 
@@ -49,4 +103,6 @@ public class WebSecurityConfig {
     public PasswordEncoder passwordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
+
+    private final JwtTokenProvider jwtTokenProvider;
 }

--- a/src/main/java/inha/capstone/fooda/domain/member/controller/AuthController.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/controller/AuthController.java
@@ -1,11 +1,14 @@
 package inha.capstone.fooda.domain.member.controller;
 
 import inha.capstone.fooda.domain.common.response.DataResponse;
+import inha.capstone.fooda.domain.member.dto.PostSigninMemberReqDto;
+import inha.capstone.fooda.domain.member.dto.PostSigninMemberResDto;
 import inha.capstone.fooda.domain.member.dto.PostSignupMemberReqDto;
 import inha.capstone.fooda.domain.member.dto.PostSignupMemberResDto;
 import inha.capstone.fooda.domain.member.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -36,5 +39,26 @@ public class AuthController {
                 .body(new DataResponse<>(
                         PostSignupMemberResDto.of(memberId)
                 ));
+    }
+
+    @Operation(
+            summary = "JWT 로그인 요청 API",
+            description = "<p>로그인하려는 아이디와 패스워드로 서버에 로그인합니다.</p>" +
+                    "<p>로그인에 성공하면 jwt access token 을 응답합니다.</p>" +
+                    "<p><strong>이후 로그인 권한이 필요한 API를 호출할 때는 HTTP header에 다음과 같이 access token을 담아서 요청해야 합니다.</strong></p>" +
+                    "<ul><li><code>Authorization: Bearer 서버로부터_받은_액세스_토큰</code></li></ul>"
+    )
+    @PostMapping("/local")
+    public ResponseEntity<DataResponse<PostSigninMemberResDto>> signIn(
+            @Valid @RequestBody PostSigninMemberReqDto postSigninMemberReqDto
+    ) {
+        String jwtToken = authService.signIn(postSigninMemberReqDto.getUsername(), postSigninMemberReqDto.getPassword());
+
+        PostSigninMemberResDto response = PostSigninMemberResDto.of(jwtToken);
+
+        return new ResponseEntity<>(
+                new DataResponse<>(response),
+                HttpStatus.OK
+        );
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/MemberDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/MemberDto.java
@@ -20,6 +20,7 @@ public class MemberDto {
     private Integer weight;
     private Integer height;
     private Integer age;
+    @Setter
     private Role role;
 
     public static MemberDto from(Member member) {

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/MemberDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/MemberDto.java
@@ -2,6 +2,7 @@ package inha.capstone.fooda.domain.member.dto;
 
 import inha.capstone.fooda.domain.member.entity.Gender;
 import inha.capstone.fooda.domain.member.entity.Member;
+import inha.capstone.fooda.domain.member.entity.Role;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,9 +20,24 @@ public class MemberDto {
     private Integer weight;
     private Integer height;
     private Integer age;
+    private Role role;
+
+    public static MemberDto from(Member member) {
+        return new MemberDto(
+                member.getId(),
+                member.getName(),
+                member.getUsername(),
+                member.getPassword(),
+                member.getGender(),
+                member.getWeight(),
+                member.getHeight(),
+                member.getAge(),
+                member.getRole()
+        );
+    }
 
     public static MemberDto of(String name, String username, String password, Gender gender, Integer weight, Integer height, Integer age) {
-        return new MemberDto(null, name, username, password, gender, weight, height, age);
+        return new MemberDto(null, name, username, password, gender, weight, height, age, null);
     }
 
     public Member toEntity() {
@@ -34,6 +50,7 @@ public class MemberDto {
                 .weight(getWeight())
                 .height(getHeight())
                 .age(getAge())
+                .role(getRole())
                 .build();
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/PostSigninMemberReqDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/PostSigninMemberReqDto.java
@@ -1,0 +1,26 @@
+package inha.capstone.fooda.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostSigninMemberReqDto {
+    @NotBlank(message = "아이디(닉네임)을 입력해주세요")
+    @Size(min = 2, message = "아이디(닉네임)이 너무 짧습니다.")
+    @Schema(example = "gildong", description = "사용자의 아이디(닉네임)")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 입력해주세요")
+    @Schema(example = "pwd1234!", description = "비밀번호")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}",
+            message = "비밀번호는 영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상씩 포함된 8자 ~ 20자의 비밀번호여야 합니다.")
+    private String password;
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/PostSigninMemberResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/PostSigninMemberResDto.java
@@ -1,0 +1,17 @@
+package inha.capstone.fooda.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostSigninMemberResDto {
+    @Schema(example = "sfadi15i0sdifj23320dsfj", description = "로그인한 사용자의 jwt 액세스 토큰")
+    private String jwtAccessToken;
+
+    public static PostSigninMemberResDto of(String jwtAccessToken) {
+        return new PostSigninMemberResDto(jwtAccessToken);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/entity/Member.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/entity/Member.java
@@ -41,8 +41,11 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private Integer age;
 
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
     @Builder
-    public Member(Long id, String name, String username, String password, Gender gender, Integer weight, Integer height, Integer age) {
+    public Member(Long id, String name, String username, String password, Gender gender, Integer weight, Integer height, Integer age, Role role) {
         this.id = id;
         this.name = name;
         this.username = username;
@@ -51,15 +54,7 @@ public class Member extends BaseEntity {
         this.weight = weight;
         this.height = height;
         this.age = age;
-    }
-
-    /**
-     * password를 암호화한다.
-     *
-     * @param passwordEncoder
-     */
-    public void encodePassword(PasswordEncoder passwordEncoder) {
-        this.password = passwordEncoder.encode(password);
+        this.role = role;
     }
 
     /**
@@ -71,6 +66,13 @@ public class Member extends BaseEntity {
      */
     public boolean matchPassword(PasswordEncoder passwordEncoder, String checkPassword) {
         return passwordEncoder.matches(checkPassword, getPassword());
+    }
+
+    /**
+     * 회원가입할 때, USER의 권한을 부여한다.
+     */
+    public void addUserAuthority() {
+        this.role = Role.USER;
     }
 
     @Override

--- a/src/main/java/inha/capstone/fooda/domain/member/entity/Member.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/entity/Member.java
@@ -6,7 +6,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Objects;
 
@@ -55,24 +54,6 @@ public class Member extends BaseEntity {
         this.height = height;
         this.age = age;
         this.role = role;
-    }
-
-    /**
-     * 비밀번호가 일치하는지 확인하는 메소드
-     *
-     * @param passwordEncoder
-     * @param checkPassword
-     * @return 비밀번호가 일치하면 true
-     */
-    public boolean matchPassword(PasswordEncoder passwordEncoder, String checkPassword) {
-        return passwordEncoder.matches(checkPassword, getPassword());
-    }
-
-    /**
-     * 회원가입할 때, USER의 권한을 부여한다.
-     */
-    public void addUserAuthority() {
-        this.role = Role.USER;
     }
 
     @Override

--- a/src/main/java/inha/capstone/fooda/domain/member/entity/Role.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/entity/Role.java
@@ -1,0 +1,5 @@
+package inha.capstone.fooda.domain.member.entity;
+
+public enum Role {
+    USER, MANAGER, ADMIN
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/exception/JwtUnauthorizedException.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/exception/JwtUnauthorizedException.java
@@ -1,0 +1,6 @@
+package inha.capstone.fooda.domain.member.exception;
+
+import inha.capstone.fooda.domain.common.exception.UnauthorizedException;
+
+public class JwtUnauthorizedException extends UnauthorizedException {
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/exception/UsernameNotFoundExcpetion.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/exception/UsernameNotFoundExcpetion.java
@@ -1,0 +1,9 @@
+package inha.capstone.fooda.domain.member.exception;
+
+import inha.capstone.fooda.domain.common.exception.NotFoundException;
+
+public class UsernameNotFoundExcpetion extends NotFoundException {
+    public UsernameNotFoundExcpetion(String optionalMessage) {
+        super(optionalMessage);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/repository/MemberRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/repository/MemberRepository.java
@@ -3,6 +3,10 @@ package inha.capstone.fooda.domain.member.repository;
 import inha.capstone.fooda.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByUsername(String username);
+
+    Optional<Member> findByUsername(String username);
 }

--- a/src/main/java/inha/capstone/fooda/domain/member/service/AuthService.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/service/AuthService.java
@@ -2,6 +2,7 @@ package inha.capstone.fooda.domain.member.service;
 
 import inha.capstone.fooda.domain.member.dto.MemberDto;
 import inha.capstone.fooda.domain.member.entity.Member;
+import inha.capstone.fooda.domain.member.entity.Role;
 import inha.capstone.fooda.domain.member.exception.JwtUnauthorizedException;
 import inha.capstone.fooda.domain.member.exception.UsernameDuplicateException;
 import inha.capstone.fooda.domain.member.exception.UsernameNotFoundExcpetion;
@@ -28,9 +29,8 @@ public class AuthService {
         }
 
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword())); // 비밀번호 암호화
-
-        Member savedMember = memberRepository.save(memberDto.toEntity());
-        savedMember.addUserAuthority(); // USER 권한 부여
+        memberDto.setRole(Role.USER); // USER 권한 부여
+        Member savedMember = memberRepository.save(memberDto.toEntity()); // 회원 저장
 
         return savedMember.getId();
     }

--- a/src/main/java/inha/capstone/fooda/domain/member/service/MemberService.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/service/MemberService.java
@@ -1,0 +1,27 @@
+package inha.capstone.fooda.domain.member.service;
+
+import inha.capstone.fooda.domain.member.dto.MemberDto;
+import inha.capstone.fooda.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    /**
+     * 유저네임(아이디)로 멤버 조회
+     *
+     * @param username 조회하려는 유저네임(아이디)
+     * @return 조회한 Member Entity
+     */
+    public MemberDto findMemberByUsername(String username) {
+        return MemberDto.from(
+                memberRepository.findByUsername(username)
+                        .orElseThrow(() -> new UsernameNotFoundException(username + "은 이미 존재하는 username 입니다.")));
+    }
+}

--- a/src/main/java/inha/capstone/fooda/security/FoodaPrinciple.java
+++ b/src/main/java/inha/capstone/fooda/security/FoodaPrinciple.java
@@ -1,0 +1,69 @@
+package inha.capstone.fooda.security;
+
+import inha.capstone.fooda.domain.member.dto.MemberDto;
+import inha.capstone.fooda.domain.member.entity.Role;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Set;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FoodaPrinciple implements UserDetails {
+    private MemberDto memberDto;
+
+    public static FoodaPrinciple of(MemberDto memberDto) {
+        return new FoodaPrinciple(memberDto);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Set<Role> roleTypes = Set.of(Role.values());
+
+        return roleTypes.stream()
+                .map(role -> new SimpleGrantedAuthority(role.name()))
+                .toList();
+    }
+
+    /**
+     * Principle 에 저장된 멤버의 id(PK) 를 조회
+     *
+     * @return Principle 에 저장된 멤버의 id(PK)
+     */
+    public Long getMemberId() {
+        return memberDto.getId();
+    }
+
+    @Override
+    public String getPassword() {
+        return memberDto.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return memberDto.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/inha/capstone/fooda/security/JwtAuthenticationFilter.java
+++ b/src/main/java/inha/capstone/fooda/security/JwtAuthenticationFilter.java
@@ -1,0 +1,83 @@
+package inha.capstone.fooda.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inha.capstone.fooda.domain.common.exception.ExceptionType;
+import inha.capstone.fooda.domain.common.response.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 모든 요청마다 작동하여, jwt token을 확인한다.
+     * 유효한 token이 있는 경우 token을 parsing해서 사용자 정보를 읽고 SecurityContext에 사용자 정보를 저장한다.
+     *
+     * @param request     HttpServletRequest 객체
+     * @param response    HttpServletResponse 객체
+     * @param filterChain FilterChain 객체
+     */
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        // Header에서 JWT 받아옴
+        String authorization = jwtTokenProvider.resolveToken(request);
+
+        if (authorization != null && authorization.startsWith("Bearer ")) {
+            String token = authorization.substring(7);
+
+            try {
+                // Token의 유효성 검증
+                jwtTokenProvider.validateToken(token);
+                // 토큰이 유효하면 토큰으로부터 유저 정보를 받아옴
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                // SecurityContext에 authentication 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception e) {
+                log.error("JwtAuthenticationFilter.doFilterInternal() ex={}", String.valueOf(e));
+                setErrorResponse(e.getClass(), response);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Exception 정보를 입력받아 응답할 error response를 설정한다.
+     *
+     * @param classType Exception의 class type
+     * @param response  HttpServletResponse 객체
+     */
+    private void setErrorResponse(
+            Class<? extends Exception> classType,
+            HttpServletResponse response
+    ) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding("utf-8");
+        response.setContentType("application/json; charset=UTF-8");
+
+        ExceptionType exceptionType = ExceptionType.fromByAuthenticationFailed(classType);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                exceptionType.getErrorCode(),
+                exceptionType.getErrorMessage()
+        );
+
+
+        new ObjectMapper().writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/security/JwtTokenProvider.java
+++ b/src/main/java/inha/capstone/fooda/security/JwtTokenProvider.java
@@ -1,0 +1,121 @@
+package inha.capstone.fooda.security;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtTokenProvider {
+
+    private static final long EXPIRED_DURATION = 7 * 24 * 60 * 60 * 1000L;   // Token 유효시간 일주일
+
+    private final UserDetailsService userDetailsService;
+
+    @Value("${JWT_SECRET_KEY}")
+    private String salt;
+    private Key secretKey;
+
+    /**
+     * 객체 초기화.
+     * jwt secret key를 Base64로 인코딩
+     */
+    @PostConstruct
+    protected void init() {
+        secretKey = Keys.hmacShaKeyFor(salt.getBytes(StandardCharsets.UTF_8));
+    }
+
+
+    /**
+     * Jwt token을 생성하여 반환한다.
+     *
+     * @param username 로그인하려는 사용자의 아이디 (유저네임)
+     * @return 생성한 jwt token
+     */
+    public String createToken(String username) {
+        Claims claims = Jwts.claims()
+                .setSubject(username);
+
+        Date now = new Date();
+        return Jwts.builder()
+                .setHeaderParam("type", "JWT")
+                .setClaims(claims)
+                .setSubject(username)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + EXPIRED_DURATION))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    /**
+     * Jwt token에서 사용자 정보 조회 후 security login 과정(UsernamePasswordAuthenticationToken)을 수행한다.
+     *
+     * @param token Jwt token
+     * @return Token을 통해 조회한 사용자 정보
+     */
+    public Authentication getAuthentication(String token) {
+        UserDetails principal = userDetailsService.loadUserByUsername(this.getUsername(token));
+        return new UsernamePasswordAuthenticationToken(principal, "", principal.getAuthorities());
+    }
+
+    /**
+     * 토큰에서 회원 정보(username)를 추출
+     *
+     * @param token Jwt token
+     * @return 추출한 회원 정보(username == username(아이디))
+     */
+    private String getUsername(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    /**
+     * Request의 header에서 token을 읽어온다.
+     *
+     * @param request HttpServletRequest 객체
+     * @return Header에서 추출한 token
+     */
+    public String resolveToken(HttpServletRequest request) {
+        return request.getHeader(HttpHeaders.AUTHORIZATION);
+    }
+
+    /**
+     * 토큰의 유효성, 만료일자 검증
+     *
+     * @param token Jwt token
+     */
+    public void validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+        } catch (Exception e) {
+            log.error("JwtTokenProvider.validateToken() ex={}", String.valueOf(e));
+            throw e;
+        }
+    }
+
+}

--- a/src/main/java/inha/capstone/fooda/security/UserDetailsServiceImpl.java
+++ b/src/main/java/inha/capstone/fooda/security/UserDetailsServiceImpl.java
@@ -1,0 +1,14 @@
+package inha.capstone.fooda.security;
+
+import inha.capstone.fooda.domain.member.service.MemberService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+@Configuration
+public class UserDetailsServiceImpl {
+    @Bean
+    public UserDetailsService userDetailsService(MemberService memberService) {
+        return username -> FoodaPrinciple.of(memberService.findMemberByUsername(username));
+    }
+}

--- a/src/test/java/inha/capstone/fooda/domain/member/service/AuthServiceTest.java
+++ b/src/test/java/inha/capstone/fooda/domain/member/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import inha.capstone.fooda.domain.member.dto.MemberDto;
 import inha.capstone.fooda.domain.member.entity.Gender;
 import inha.capstone.fooda.domain.member.entity.Member;
 import inha.capstone.fooda.domain.member.repository.MemberRepository;
+import inha.capstone.fooda.security.JwtTokenProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -25,6 +27,8 @@ class AuthServiceTest {
     private MemberRepository memberRepository;
     @Mock
     private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
 
     @Test
     public void 유저정보가_주어지면_회원가입을_수행한다() {
@@ -48,5 +52,20 @@ class AuthServiceTest {
 
     private MemberDto createMemberDto() {
         return MemberDto.of("멤버1", "member1", "pwd1234!", Gender.MALE, 70, 180, 25);
+    }
+
+    @Test
+    public void 유저네임이_주어지면_jwt토큰_생성한다() {
+        //given
+        String username = "gildong";
+        String expected = "token";
+        given(jwtTokenProvider.createToken(username)).willReturn(expected);
+
+        //when
+        String result = authService.createToken(username);
+
+        //then
+        assertThat(result).isEqualTo(expected);
+        then(jwtTokenProvider).should().createToken(username);
     }
 }


### PR DESCRIPTION
### 관련 이슈
- #9 

### 작업 사항
- 로그인 API 구현

### 특이사항
- 회원의 권한 설정을 위해 Member 엔티티에 Enum 타입의 Role을 추가되었습니다.
- 회원가입 서비스 코드에서 Role을 설정하는 코드가 추가되었습니다.
- 이제 회원의 정보가 필요한 모든 컨트롤러에서 @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle 을 추가해야 합니다.