### PR TITLE
[ #22 ] 피드 업로드 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    // Validation
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '2.5.2'
+
     // Database Mysql
     runtimeOnly 'mysql:mysql-connector-java:8.0.32'
 

--- a/src/main/java/inha/capstone/fooda/config/S3Config.java
+++ b/src/main/java/inha/capstone/fooda/config/S3Config.java
@@ -1,0 +1,33 @@
+package inha.capstone.fooda.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/common/exception/ExceptionType.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/exception/ExceptionType.java
@@ -1,5 +1,6 @@
 package inha.capstone.fooda.domain.common.exception;
 
+import inha.capstone.fooda.domain.feed_image.exception.NotImageFileExcpetion;
 import inha.capstone.fooda.domain.member.exception.UsernameDuplicateException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,6 +23,7 @@ public enum ExceptionType {
     BAD_REQUEST_EXCEPTION(1, "요청 데이터가 잘못되었습니다.", null),
     ACCESS_DENIED_EXCEPTION(2, "권한이 유효하지 않습니다.", null),
     AUTHENTICATION_EXCEPTION(3, "인증 과정에서 문제가 발생했습니다.", null),
+    NOT_IMAGE_EXCEPTION(4, "이미지 파일이 아닙니다.", NotImageFileExcpetion.class),
 
     // Auth
     USERNAME_DUPLICATE_EXEPTION(1000, "아이디(유저네임)이 중복됩니다.", UsernameDuplicateException.class);

--- a/src/main/java/inha/capstone/fooda/domain/common/response/GlobalExceptionHandler.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/response/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -28,6 +29,18 @@ public class GlobalExceptionHandler {
 
         int errorCode = ExceptionType.BAD_REQUEST_EXCEPTION.getErrorCode();
         String errorMessage = ExceptionType.BAD_REQUEST_EXCEPTION.getErrorMessage() + " " + e.getAllErrors().get(0).getDefaultMessage();
+
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse(errorCode, errorMessage));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> methodMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        log.error("MaxUploadSizeExceededException: {}", String.valueOf(e));
+
+        int errorCode = ExceptionType.BAD_REQUEST_EXCEPTION.getErrorCode();
+        String errorMessage = "파일 최대 크기 초과";
 
         return ResponseEntity
                 .badRequest()

--- a/src/main/java/inha/capstone/fooda/domain/common/service/S3Service.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/service/S3Service.java
@@ -1,0 +1,35 @@
+package inha.capstone.fooda.domain.common.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class S3Service {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+
+    public String upload(MultipartFile multipartFile, String fileName) throws IOException {
+        String ext = multipartFile.getContentType();
+
+        // 이미지 검사
+
+        ObjectMetadata objMeta = new ObjectMetadata();
+        objMeta.setContentLength(multipartFile.getInputStream().available());
+
+        amazonS3.putObject(bucket, fileName, multipartFile.getInputStream(), objMeta);
+
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,7 +35,7 @@ public class FeedController {
             summary = "음식 기록 API",
             description = "<p>음식을 기록합니다.</p>"
     )
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<DataResponse<PostFeedResDto>> feed(
             @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle,
             @Valid PostFeedReqDto postFeedReqDto

--- a/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
@@ -1,0 +1,48 @@
+package inha.capstone.fooda.domain.feed.controller;
+
+import inha.capstone.fooda.domain.common.response.DataResponse;
+import inha.capstone.fooda.domain.feed.dto.PostFeedReqDto;
+import inha.capstone.fooda.domain.feed.dto.PostFeedResDto;
+import inha.capstone.fooda.domain.feed.service.FeedService;
+import inha.capstone.fooda.domain.friend.dto.GetFindFriendInfoResDto;
+import inha.capstone.fooda.domain.friend.service.FriendService;
+import inha.capstone.fooda.domain.member.dto.MemberDto;
+import inha.capstone.fooda.security.FoodaPrinciple;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.List;
+
+@Tag(name = "Feed")
+@RequiredArgsConstructor
+@RequestMapping("/api/feed")
+@RestController
+public class FeedController {
+    private final FeedService feedService;
+
+    @Operation(
+            summary = "음식 기록 API",
+            description = "<p>음식을 기록합니다.</p>"
+    )
+    @PostMapping
+    public ResponseEntity<DataResponse<PostFeedResDto>> feed(
+            @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle,
+            @Valid PostFeedReqDto postFeedReqDto
+    ) throws IOException {
+        feedService.uploadFeed(principle.getMemberId(), postFeedReqDto.getOpen(), postFeedReqDto.getMeal(), postFeedReqDto.getImg());
+        return new ResponseEntity<>(
+                new DataResponse<>(new PostFeedResDto("ok")),
+                HttpStatus.OK
+        );
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
@@ -39,9 +39,9 @@ public class FeedController {
             @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle,
             @Valid PostFeedReqDto postFeedReqDto
     ) throws IOException {
-        feedService.uploadFeed(principle.getMemberId(), postFeedReqDto.getOpen(), postFeedReqDto.getMeal(), postFeedReqDto.getImg());
+        long id = feedService.uploadFeed(principle.getMemberId(), postFeedReqDto.getOpen(), postFeedReqDto.getMeal(), postFeedReqDto.getImg());
         return new ResponseEntity<>(
-                new DataResponse<>(new PostFeedResDto("ok")),
+                new DataResponse<>(new PostFeedResDto(id)),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedReqDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedReqDto.java
@@ -6,10 +6,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostFeedReqDto {
-    private MultipartFile img;
+    private List<MultipartFile> img;
     private Boolean open;
     private Menu meal;
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedReqDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedReqDto.java
@@ -1,0 +1,15 @@
+package inha.capstone.fooda.domain.feed.dto;
+
+import inha.capstone.fooda.domain.feed.entity.Menu;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostFeedReqDto {
+    private MultipartFile img;
+    private Boolean open;
+    private Menu meal;
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedResDto.java
@@ -1,0 +1,13 @@
+package inha.capstone.fooda.domain.feed.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class PostFeedResDto {
+    @Schema(example = "ok", description = "성공")
+    private String ok;
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedResDto.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class PostFeedResDto {
-    @Schema(example = "ok", description = "성공")
-    private String ok;
+    @Schema(example = "3", description = "업로드한 피드의 ID")
+    private Long id;
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed/entity/Feed.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/entity/Feed.java
@@ -4,6 +4,7 @@ import inha.capstone.fooda.domain.common.entity.BaseEntity;
 import inha.capstone.fooda.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,5 +41,13 @@ public class Feed extends BaseEntity {
     @Override
     public int hashCode() {
         return Objects.hash(this.getId());
+    }
+
+    @Builder
+    public Feed(Long id, Member member, Boolean open, Menu menu) {
+        this.id = id;
+        this.member = member;
+        this.open = open;
+        this.menu = menu;
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/repository/FeedRepository.java
@@ -1,0 +1,12 @@
+package inha.capstone.fooda.domain.feed.repository;
+
+import inha.capstone.fooda.domain.feed.entity.Feed;
+import inha.capstone.fooda.domain.friend.entity.Friend;
+import inha.capstone.fooda.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
@@ -27,21 +27,21 @@ public class FeedService {
 
     @Transactional
     public long uploadFeed(Long memberId, Boolean open, Menu menu, List<MultipartFile> imgs) throws IOException {
-        Feed feed = saveFeed(memberId, open, menu);
+        Long feedId = saveFeed(memberId, open, menu);
         for (MultipartFile img : imgs) {
-            feedImageService.uploadFeedImage(img, feed.getId());
+            feedImageService.uploadFeedImage(img, feedId);
         }
-        return feed.getId();
+        return feedId;
     }
 
     @Transactional
-    public Feed saveFeed(Long memberId, Boolean open, Menu menu) {
+    public Long saveFeed(Long memberId, Boolean open, Menu menu) {
         Feed feed = Feed.builder()
                 .member(memberRepository.getReferenceById(memberId))
                 .open(open)
                 .menu(menu)
                 .build();
         feedRepository.save(feed);
-        return feed;
+        return feed.getId();
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
@@ -19,15 +19,18 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class FeedService {
     private final FeedRepository feedRepository;
     private final FeedImageService feedImageService;
     private final MemberRepository memberRepository;
 
-    public void uploadFeed(Long memberId, Boolean open, Menu menu, MultipartFile img) throws IOException {
+    public long uploadFeed(Long memberId, Boolean open, Menu menu, List<MultipartFile> imgs) throws IOException {
         Feed feed = saveFeed(memberId, open, menu);
-        feedImageService.uploadFeedImage(img, feed);
+        for (MultipartFile img : imgs) {
+            feedImageService.uploadFeedImage(img, feed.getId());
+        }
+        return feed.getId();
     }
 
     public Feed saveFeed(Long memberId, Boolean open, Menu menu) {

--- a/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
@@ -19,12 +19,13 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class FeedService {
     private final FeedRepository feedRepository;
     private final FeedImageService feedImageService;
     private final MemberRepository memberRepository;
 
+    @Transactional
     public long uploadFeed(Long memberId, Boolean open, Menu menu, List<MultipartFile> imgs) throws IOException {
         Feed feed = saveFeed(memberId, open, menu);
         for (MultipartFile img : imgs) {
@@ -33,6 +34,7 @@ public class FeedService {
         return feed.getId();
     }
 
+    @Transactional
     public Feed saveFeed(Long memberId, Boolean open, Menu menu) {
         Feed feed = Feed.builder()
                 .member(memberRepository.getReferenceById(memberId))

--- a/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
@@ -1,0 +1,42 @@
+package inha.capstone.fooda.domain.feed.service;
+
+import inha.capstone.fooda.domain.feed.entity.Feed;
+import inha.capstone.fooda.domain.feed.entity.Menu;
+import inha.capstone.fooda.domain.feed.repository.FeedRepository;
+import inha.capstone.fooda.domain.feed_image.service.FeedImageService;
+import inha.capstone.fooda.domain.friend.repository.FriendRepository;
+import inha.capstone.fooda.domain.member.dto.MemberDto;
+import inha.capstone.fooda.domain.member.entity.Member;
+import inha.capstone.fooda.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FeedService {
+    private final FeedRepository feedRepository;
+    private final FeedImageService feedImageService;
+    private final MemberRepository memberRepository;
+
+    public void uploadFeed(Long memberId, Boolean open, Menu menu, MultipartFile img) throws IOException {
+        Feed feed = saveFeed(memberId, open, menu);
+        feedImageService.uploadFeedImage(img, feed);
+    }
+
+    public Feed saveFeed(Long memberId, Boolean open, Menu menu) {
+        Feed feed = Feed.builder()
+                .member(memberRepository.getReferenceById(memberId))
+                .open(open)
+                .menu(menu)
+                .build();
+        feedRepository.save(feed);
+        return feed;
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed_image/entity/FeedImage.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed_image/entity/FeedImage.java
@@ -2,8 +2,11 @@ package inha.capstone.fooda.domain.feed_image.entity;
 
 import inha.capstone.fooda.domain.common.entity.BaseEntity;
 import inha.capstone.fooda.domain.feed.entity.Feed;
+import inha.capstone.fooda.domain.feed.entity.Menu;
+import inha.capstone.fooda.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -42,5 +45,14 @@ public class FeedImage extends BaseEntity {
     @Override
     public int hashCode() {
         return Objects.hash(this.getId());
+    }
+
+    @Builder
+    public FeedImage(Long id, Feed feed, String fileName, String fileNameStored, String url) {
+        this.id = id;
+        this.feed = feed;
+        this.fileName = fileName;
+        this.fileNameStored = fileNameStored;
+        this.url = url;
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed_image/exception/NotImageFileExcpetion.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed_image/exception/NotImageFileExcpetion.java
@@ -1,0 +1,10 @@
+package inha.capstone.fooda.domain.feed_image.exception;
+
+import inha.capstone.fooda.domain.common.exception.BadRequestException;
+import inha.capstone.fooda.domain.common.exception.NotFoundException;
+
+public class NotImageFileExcpetion extends BadRequestException {
+    public NotImageFileExcpetion() {
+        super();
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed_image/repository/FeedImageRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed_image/repository/FeedImageRepository.java
@@ -1,0 +1,9 @@
+package inha.capstone.fooda.domain.feed_image.repository;
+
+import inha.capstone.fooda.domain.feed.entity.Feed;
+import inha.capstone.fooda.domain.feed_image.entity.FeedImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedImageRepository extends JpaRepository<FeedImage, Long> {
+
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
@@ -5,6 +5,7 @@ import inha.capstone.fooda.domain.feed.entity.Feed;
 import inha.capstone.fooda.domain.feed.entity.Menu;
 import inha.capstone.fooda.domain.feed.repository.FeedRepository;
 import inha.capstone.fooda.domain.feed_image.entity.FeedImage;
+import inha.capstone.fooda.domain.feed_image.exception.NotImageFileExcpetion;
 import inha.capstone.fooda.domain.feed_image.repository.FeedImageRepository;
 import inha.capstone.fooda.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
@@ -12,22 +13,30 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.imageio.ImageIO;
+import java.awt.*;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class FeedImageService {
     private final FeedImageRepository feedImageRepository;
+    private final FeedRepository feedRepository;
     private final S3Service s3Service;
 
-    public void uploadFeedImage(MultipartFile img, Feed feed) throws IOException {
+    public void uploadFeedImage(MultipartFile img, Long feedId) throws IOException {
+
+        // 이미지 파일인지 검사하는 로직
+        Image image = ImageIO.read(img.getInputStream());
+        if (image == null) throw new NotImageFileExcpetion();
+
         String fileName = UUID.randomUUID().toString();
         String url = s3Service.upload(img, fileName);
         FeedImage feedImage = FeedImage.builder()
-                .feed(feed)
+                .feed(feedRepository.getReferenceById(feedId))
                 .fileNameStored(fileName)
                 .fileName(img.getOriginalFilename())
                 .url(url)

--- a/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
@@ -1,0 +1,37 @@
+package inha.capstone.fooda.domain.feed_image.service;
+
+import inha.capstone.fooda.domain.common.service.S3Service;
+import inha.capstone.fooda.domain.feed.entity.Feed;
+import inha.capstone.fooda.domain.feed.entity.Menu;
+import inha.capstone.fooda.domain.feed.repository.FeedRepository;
+import inha.capstone.fooda.domain.feed_image.entity.FeedImage;
+import inha.capstone.fooda.domain.feed_image.repository.FeedImageRepository;
+import inha.capstone.fooda.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FeedImageService {
+    private final FeedImageRepository feedImageRepository;
+    private final S3Service s3Service;
+
+    public void uploadFeedImage(MultipartFile img, Feed feed) throws IOException {
+        String fileName = UUID.randomUUID().toString();
+        String url = s3Service.upload(img, fileName);
+        FeedImage feedImage = FeedImage.builder()
+                .feed(feed)
+                .fileNameStored(fileName)
+                .fileName(img.getOriginalFilename())
+                .url(url)
+                .build();
+        feedImageRepository.save(feedImage);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
@@ -21,12 +21,13 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class FeedImageService {
     private final FeedImageRepository feedImageRepository;
     private final FeedRepository feedRepository;
     private final S3Service s3Service;
 
+    @Transactional
     public void uploadFeedImage(MultipartFile img, Long feedId) throws IOException {
 
         // 이미지 파일인지 검사하는 로직

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,10 @@ spring:
     password: ${FOODA_DB_PASSWORD_DEV}
     driver-class-name: com.mysql.cj.jdbc.Driver
   sql.init.mode: always
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 cloud:
   aws:
     s3:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,3 +15,15 @@ spring:
     password: ${FOODA_DB_PASSWORD_DEV}
     driver-class-name: com.mysql.cj.jdbc.Driver
   sql.init.mode: always
+cloud:
+  aws:
+    s3:
+      bucket: fooda-bucket
+    credentials:
+      accessKey: ${FOODA_BUCKET_ACCESSKEY_DEV}
+      secretKey: ${FOODA_BUCKET_SECRETKEY_DEV}
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,3 +15,15 @@ spring:
     password: ${FOODA_DB_PASSWORD_PROD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   sql.init.mode: always
+cloud:
+  aws:
+    s3:
+      bucket: fooda-bucket
+    credentials:
+      accessKey: AKIAZAMETMX3VGGFAN7Y
+      secretKey: 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
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,6 +15,10 @@ spring:
     password: ${FOODA_DB_PASSWORD_PROD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   sql.init.mode: always
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 cloud:
   aws:
     s3:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,8 +20,8 @@ cloud:
     s3:
       bucket: fooda-bucket
     credentials:
-      accessKey: AKIAZAMETMX3VGGFAN7Y
-      secretKey: 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
+      accessKey: ${FOODA_BUCKET_ACCESSKEY_PROD}
+      secretKey: ${FOODA_BUCKET_SECRETKEY_PROD}
     region:
       static: ap-northeast-2
       auto: false


### PR DESCRIPTION
### 관련 이슈
- #22

### 작업 사항
- 피드 업로드 API
- 음식 사진 업로드
- AWS S3 서버 설정

### 첨부
- <img width="589" alt="image" src="https://github.com/pix-el-wave/fooda-backend/assets/76799354/6e018f1d-9035-485c-a141-ed8111c09007">


### 특이사항
- 이미지 검사시 ImageIO 이용