### PR TITLE
[ #19 ] 팔로워, 팔로잉 목록 조회 서비스 메소드 수정

### DIFF
--- a/src/main/java/inha/capstone/fooda/domain/friend/dto/FriendDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/friend/dto/FriendDto.java
@@ -10,22 +10,22 @@ import lombok.Getter;
 @Getter
 public class FriendDto {
     private Long id;
-    private Member following;
     private Member follower;
+    private Member following;
 
-    public static FriendDto from(Friend friend){
+    public static FriendDto from(Friend friend) {
         return new FriendDto(
                 friend.getId(),
-                friend.getFollowing(),
-                friend.getFollower()
+                friend.getFollower(),
+                friend.getFollowing()
         );
     }
 
-    public static FriendDto of(Member following, Member follower){
-        return new FriendDto(null, following, follower);
+    public static FriendDto of(Member follower, Member following) {
+        return new FriendDto(null, follower, following);
     }
 
-    public Friend toEntity(){
+    public Friend toEntity() {
         return Friend.builder()
                 .id(getId())
                 .follower(getFollower())

--- a/src/main/java/inha/capstone/fooda/domain/friend/entity/Friend.java
+++ b/src/main/java/inha/capstone/fooda/domain/friend/entity/Friend.java
@@ -20,18 +20,18 @@ public class Friend extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "following_id")
-    private Member following;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_id")
     private Member follower;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id")
+    private Member following;
+
     @Builder
-    public Friend(Long id, Member following, Member follower) {
+    public Friend(Long id, Member follower, Member following) {
         this.id = id;
-        this.following = following;
         this.follower = follower;
+        this.following = following;
     }
 
     @Override

--- a/src/main/java/inha/capstone/fooda/domain/friend/service/FriendService.java
+++ b/src/main/java/inha/capstone/fooda/domain/friend/service/FriendService.java
@@ -25,10 +25,10 @@ public class FriendService {
      * @return 조회된 MemberDto 리스트
      */
     public List<MemberDto> findFollowingMembers(String username) {
-        return friendRepository.findByFollowing(findMemberByUsername(username))
+        return friendRepository.findByFollower(findMemberByUsername(username))
                 .stream()
                 .map(friend ->
-                        MemberDto.from(findMemberByUsername(friend.getFollower().getUsername())))
+                        MemberDto.from(findMemberByUsername(friend.getFollowing().getUsername())))
                 .toList();
     }
 
@@ -39,10 +39,10 @@ public class FriendService {
      * @return 조회된 MemberDto 리스트\
      */
     public List<MemberDto> findFollowerMembers(String username) {
-        return friendRepository.findByFollower(findMemberByUsername(username))
+        return friendRepository.findByFollowing(findMemberByUsername(username))
                 .stream()
                 .map(friend ->
-                        MemberDto.from(findMemberByUsername(friend.getFollowing().getUsername())))
+                        MemberDto.from(findMemberByUsername(friend.getFollower().getUsername())))
                 .toList();
     }
 

--- a/src/test/java/inha/capstone/fooda/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/inha/capstone/fooda/domain/friend/service/FriendServiceTest.java
@@ -34,7 +34,7 @@ public class FriendServiceTest {
     public void 유저네임이_주어지면_유저의_팔로잉_목록을_조회한다() {
         //given
         String username = "member1";
-        given(friendRepository.findByFollowing(any(Member.class))).willReturn(createFriendList(createFollowingDtoList()));
+        given(friendRepository.findByFollower(any(Member.class))).willReturn(createFriendList(createFollowingDtoList()));
         given(memberRepository.findByUsername(any(String.class))).willReturn(Optional.of(createMember("member1", "member1", 1L)));
 
         //when
@@ -52,10 +52,10 @@ public class FriendServiceTest {
         given(memberRepository.findByUsername(any(String.class))).willReturn(Optional.of(createMember("member1", "member1", 1L)));
 
         //when
-        List<MemberDto> followingMembers = friendService.findFollowingMembers(username);
+        List<MemberDto> followerMembers = friendService.findFollowerMembers(username);
 
         //then
-        Assertions.assertThat(followingMembers.size()).isEqualTo(2);
+        Assertions.assertThat(followerMembers.size()).isEqualTo(2);
     }
 
     private List<Friend> createFriendList(List<FriendDto> friendDtos) {


### PR DESCRIPTION
### 관련 이슈
- #19 

### 작업 사항
- 기존 FriendService에서 팔로워 목록 조회, 팔로잉 목록 조회 부분에서 팔로워, 팔로잉 네임이 좀 헷갈리게 되어 있었습니다. 이 부분 좀 더 직관적으로 이해할 수 있도록 변경했습니다.