### PR TITLE
[ #30 ] AI fast api 서버 구축 / 음식 사진에서 음식 목록 추출을 무작위하게 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 
     // S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/inha/capstone/fooda/config/AICommunicationServerConfig.java
+++ b/src/main/java/inha/capstone/fooda/config/AICommunicationServerConfig.java
@@ -14,7 +14,7 @@ public class AICommunicationServerConfig {
     private String AICommunicationServerUrl;
 
     @Bean
-    public WebClient llmCommunicationServerWebClient() {
+    public WebClient aiCommunicationServerWebClient() {
         return WebClient.builder()
                 .baseUrl(AICommunicationServerUrl)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/inha/capstone/fooda/config/AICommunicationServerConfig.java
+++ b/src/main/java/inha/capstone/fooda/config/AICommunicationServerConfig.java
@@ -1,0 +1,23 @@
+package inha.capstone.fooda.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class AICommunicationServerConfig {
+
+    @Value("${ai.python.url}")
+    private String AICommunicationServerUrl;
+
+    @Bean
+    public WebClient llmCommunicationServerWebClient() {
+        return WebClient.builder()
+                .baseUrl(AICommunicationServerUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
@@ -8,6 +8,8 @@ import inha.capstone.fooda.domain.friend.dto.GetFindFriendInfoResDto;
 import inha.capstone.fooda.domain.friend.service.FriendService;
 import inha.capstone.fooda.domain.member.dto.MemberDto;
 import inha.capstone.fooda.security.FoodaPrinciple;
+import inha.capstone.fooda.utils.AIServerBaseResDto;
+import inha.capstone.fooda.utils.FoodListResDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,7 +24,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Tag(name = "Feed")
 @RequiredArgsConstructor
@@ -36,13 +40,13 @@ public class FeedController {
             description = "<p>음식을 기록합니다.</p>"
     )
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<DataResponse<PostFeedResDto>> feed(
+    public ResponseEntity<DataResponse<List<FoodListResDto>>> feed(
             @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle,
             @Valid PostFeedReqDto postFeedReqDto
     ) throws IOException {
-        long id = feedService.uploadFeed(principle.getMemberId(), postFeedReqDto.getOpen(), postFeedReqDto.getMeal(), postFeedReqDto.getImg());
+        List<FoodListResDto> all = feedService.uploadFeed(principle.getMemberId(), postFeedReqDto.getOpen(), postFeedReqDto.getMeal(), postFeedReqDto.getImg());
         return new ResponseEntity<>(
-                new DataResponse<>(new PostFeedResDto(id)),
+                new DataResponse<>(all),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
@@ -5,12 +5,7 @@ import inha.capstone.fooda.domain.feed.dto.PostFeedReqDto;
 import inha.capstone.fooda.domain.feed.dto.PostFeedResDto;
 import inha.capstone.fooda.domain.feed.dto.UploadFeedDto;
 import inha.capstone.fooda.domain.feed.service.FeedService;
-import inha.capstone.fooda.domain.friend.dto.GetFindFriendInfoResDto;
-import inha.capstone.fooda.domain.friend.service.FriendService;
-import inha.capstone.fooda.domain.member.dto.MemberDto;
 import inha.capstone.fooda.security.FoodaPrinciple;
-import inha.capstone.fooda.utils.AIServerBaseResDto;
-import inha.capstone.fooda.utils.FoodListResDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,9 +20,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 @Tag(name = "Feed")
 @RequiredArgsConstructor

--- a/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
@@ -3,6 +3,7 @@ package inha.capstone.fooda.domain.feed.controller;
 import inha.capstone.fooda.domain.common.response.DataResponse;
 import inha.capstone.fooda.domain.feed.dto.PostFeedReqDto;
 import inha.capstone.fooda.domain.feed.dto.PostFeedResDto;
+import inha.capstone.fooda.domain.feed.dto.UploadFeedDto;
 import inha.capstone.fooda.domain.feed.service.FeedService;
 import inha.capstone.fooda.domain.friend.dto.GetFindFriendInfoResDto;
 import inha.capstone.fooda.domain.friend.service.FriendService;
@@ -40,13 +41,13 @@ public class FeedController {
             description = "<p>음식을 기록합니다.</p>"
     )
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<DataResponse<List<FoodListResDto>>> feed(
+    public ResponseEntity<DataResponse<PostFeedResDto>> feed(
             @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle,
             @Valid PostFeedReqDto postFeedReqDto
     ) throws IOException {
-        List<FoodListResDto> all = feedService.uploadFeed(principle.getMemberId(), postFeedReqDto.getOpen(), postFeedReqDto.getMeal(), postFeedReqDto.getImg());
+        UploadFeedDto uploadFeedDto = feedService.uploadFeed(principle.getMemberId(), postFeedReqDto.getOpen(), postFeedReqDto.getMeal(), postFeedReqDto.getImg());
         return new ResponseEntity<>(
-                new DataResponse<>(all),
+                new DataResponse<>(new PostFeedResDto(uploadFeedDto)),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedReqDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedReqDto.java
@@ -1,6 +1,8 @@
 package inha.capstone.fooda.domain.feed.dto;
 
 import inha.capstone.fooda.domain.feed.entity.Menu;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,7 +13,16 @@ import java.util.List;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostFeedReqDto {
+
+    @NotNull(message = "이미지를 최소 1개 업로드해 주세요.")
+    @Schema(description = "음식 사진")
     private List<MultipartFile> img;
+
+    @NotNull(message = "친구 공개 여부를 선택해주세요.")
+    @Schema(description = "친구 공개 여부")
     private Boolean open;
+
+    @NotNull(message = "식사 종류를 선택해주세요.")
+    @Schema(description = "식사 종류")
     private Menu meal;
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedResDto.java
@@ -15,6 +15,7 @@ public class PostFeedResDto {
     @Schema(example = "3", description = "업로드한 피드의 ID")
     private Long feedId;
 
+    @Schema(example = "[{\"no\":1,\"name\":\"Pizza\",\"size\":200,\"energy\":250.5,\"protein\":10.2,\"province\":5.5,\"carbohydrate\":30.0,\"calcium\":50.2,\"salt\":1.5}, {\"no\":2,\"name\":\"Burger\",\"size\":150,\"energy\":300.0,\"protein\":12.5,\"province\":6.0,\"carbohydrate\":25.0,\"calcium\":40.5,\"salt\":1.8}]", description = "이미지에서 추출된 음식 목록")
     List<FoodListResDto> foodList;
 
     public PostFeedResDto(UploadFeedDto uploadFeedDto) {

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedResDto.java
@@ -1,13 +1,24 @@
 package inha.capstone.fooda.domain.feed.dto;
 
+import inha.capstone.fooda.utils.FoodListResDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class PostFeedResDto {
+
     @Schema(example = "3", description = "업로드한 피드의 ID")
-    private Long id;
+    private Long feedId;
+
+    List<FoodListResDto> foodList;
+
+    public PostFeedResDto(UploadFeedDto uploadFeedDto) {
+        this.feedId = uploadFeedDto.getFeedId();
+        this.foodList = uploadFeedDto.getFoodList();
+    }
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/UploadFeedDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/UploadFeedDto.java
@@ -1,0 +1,14 @@
+package inha.capstone.fooda.domain.feed.dto;
+
+import inha.capstone.fooda.utils.FoodListResDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class UploadFeedDto {
+    private Long feedId;
+    private List<FoodListResDto> foodList;
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
@@ -4,17 +4,17 @@ import inha.capstone.fooda.domain.feed.entity.Feed;
 import inha.capstone.fooda.domain.feed.entity.Menu;
 import inha.capstone.fooda.domain.feed.repository.FeedRepository;
 import inha.capstone.fooda.domain.feed_image.service.FeedImageService;
-import inha.capstone.fooda.domain.friend.repository.FriendRepository;
-import inha.capstone.fooda.domain.member.dto.MemberDto;
-import inha.capstone.fooda.domain.member.entity.Member;
 import inha.capstone.fooda.domain.member.repository.MemberRepository;
+import inha.capstone.fooda.utils.AICommunicationUtils;
+import inha.capstone.fooda.utils.FoodListReqDto;
+import inha.capstone.fooda.utils.FoodListResDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -25,13 +25,17 @@ public class FeedService {
     private final FeedImageService feedImageService;
     private final MemberRepository memberRepository;
 
+    private final AICommunicationUtils aiCommunicationUtils;
+
     @Transactional
-    public long uploadFeed(Long memberId, Boolean open, Menu menu, List<MultipartFile> imgs) throws IOException {
+    public List<FoodListResDto> uploadFeed(Long memberId, Boolean open, Menu menu, List<MultipartFile> imgs) throws IOException {
         Long feedId = saveFeed(memberId, open, menu);
+        List<FoodListResDto> all = new ArrayList<>();
         for (MultipartFile img : imgs) {
-            feedImageService.uploadFeedImage(img, feedId);
+            String url = feedImageService.uploadFeedImage(img, feedId);
+            all.addAll(aiCommunicationUtils.requestImageList(new FoodListReqDto(url)).getData());
         }
-        return feedId;
+        return all;
     }
 
     @Transactional

--- a/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
@@ -1,5 +1,6 @@
 package inha.capstone.fooda.domain.feed.service;
 
+import inha.capstone.fooda.domain.feed.dto.UploadFeedDto;
 import inha.capstone.fooda.domain.feed.entity.Feed;
 import inha.capstone.fooda.domain.feed.entity.Menu;
 import inha.capstone.fooda.domain.feed.repository.FeedRepository;
@@ -28,14 +29,14 @@ public class FeedService {
     private final AICommunicationUtils aiCommunicationUtils;
 
     @Transactional
-    public List<FoodListResDto> uploadFeed(Long memberId, Boolean open, Menu menu, List<MultipartFile> imgs) throws IOException {
+    public UploadFeedDto uploadFeed(Long memberId, Boolean open, Menu menu, List<MultipartFile> imgs) throws IOException {
         Long feedId = saveFeed(memberId, open, menu);
-        List<FoodListResDto> all = new ArrayList<>();
+        List<FoodListResDto> foodList = new ArrayList<>();
         for (MultipartFile img : imgs) {
             String url = feedImageService.uploadFeedImage(img, feedId);
-            all.addAll(aiCommunicationUtils.requestImageList(new FoodListReqDto(url)).getData());
+            foodList.addAll(aiCommunicationUtils.requestImageList(new FoodListReqDto(url)).getData());
         }
-        return all;
+        return new UploadFeedDto(feedId, foodList);
     }
 
     @Transactional

--- a/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
@@ -28,7 +28,7 @@ public class FeedImageService {
     private final S3Service s3Service;
 
     @Transactional
-    public void uploadFeedImage(MultipartFile img, Long feedId) throws IOException {
+    public String uploadFeedImage(MultipartFile img, Long feedId) throws IOException {
 
         // 이미지 파일인지 검사하는 로직
         Image image = ImageIO.read(img.getInputStream());
@@ -43,5 +43,6 @@ public class FeedImageService {
                 .url(url)
                 .build();
         feedImageRepository.save(feedImage);
+        return url;
     }
 }

--- a/src/main/java/inha/capstone/fooda/utils/AICommunicationUtils.java
+++ b/src/main/java/inha/capstone/fooda/utils/AICommunicationUtils.java
@@ -1,0 +1,44 @@
+package inha.capstone.fooda.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AICommunicationUtils {
+    private final WebClient aiCommunicationServerWebClient;
+
+    public static final String IMAGE_FOOD_LIST_URI = "/image";
+
+    private <T, R> R sendPostRequestWithBlocking(String uri, T requestBody, ParameterizedTypeReference<R> responseTypeReference) throws WebClientResponseException {
+        long startTime = System.currentTimeMillis();
+        log.info(uri);
+        try {
+            return aiCommunicationServerWebClient
+                    .post()
+                    .uri(uri)
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(responseTypeReference)
+                    .block();
+        } catch (WebClientResponseException e) {
+            e.printStackTrace();
+            log.error("FastAPI Server Communication Error, API uri: " + uri);
+            throw e;
+        } finally {
+            log.info("Time spent calling the api '" + uri + "' : " + (System.currentTimeMillis() - startTime) + "ms");
+        }
+    }
+
+    public AIServerBaseResDto<List<FoodListResDto>> requestImageList(FoodListReqDto requestImageListReqDto) throws WebClientResponseException {
+        ParameterizedTypeReference<AIServerBaseResDto<List<FoodListResDto>>> typeReference = new ParameterizedTypeReference<>() {};
+        return this.sendPostRequestWithBlocking(IMAGE_FOOD_LIST_URI, requestImageListReqDto, typeReference);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/utils/AIServerBaseResDto.java
+++ b/src/main/java/inha/capstone/fooda/utils/AIServerBaseResDto.java
@@ -1,0 +1,11 @@
+package inha.capstone.fooda.utils;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class AIServerBaseResDto<T> {
+    private T data;
+    private Boolean success;
+}

--- a/src/main/java/inha/capstone/fooda/utils/FoodListReqDto.java
+++ b/src/main/java/inha/capstone/fooda/utils/FoodListReqDto.java
@@ -1,0 +1,10 @@
+package inha.capstone.fooda.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class FoodListReqDto {
+    private String url;
+}

--- a/src/main/java/inha/capstone/fooda/utils/FoodListResDto.java
+++ b/src/main/java/inha/capstone/fooda/utils/FoodListResDto.java
@@ -1,0 +1,20 @@
+package inha.capstone.fooda.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class FoodListResDto {
+    private Integer no;
+    private String name;
+    private Integer size;
+    private Float energy;
+    private Float protein;
+    private Float province;
+    private Float carbohydrate;
+    private Float calcium;
+    private Float salt;
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,3 +31,6 @@ cloud:
       auto: false
     stack:
       auto: false
+ai:
+  python:
+    url: ${FOODA_AI_URL_DEV}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -31,3 +31,6 @@ cloud:
       auto: false
     stack:
       auto: false
+ai:
+  python:
+    url: ${FOODA_AI_URL_PROD}


### PR DESCRIPTION
### 관련 이슈
- #30 

### 작업 사항
- AI fast api 서버 구축
- spring 서버와 ai 서버 연결
- 음식 사진에서 음식 목록 추출을 무작위하게 구현 ( 아직 AI 쪽 미완으로 인해 무작위로 구현 )
- 기존 음식 사진 추가하면 추가된 피드의 id를 반환하던 것을 추출된 음식 리스트와 영양분을 함께 반환하도록 변경

### 첨부
- <img width="1127" alt="image" src="https://github.com/pix-el-wave/fooda-backend/assets/76799354/b0ce010c-9b35-4eb3-9a3c-0452be520d89">


### 특이사항
- webflux 도입
- 추후 FrontEnd는 반환받은 음식리스트를 적절하게 수정하여 다시 백엔드에게 전송