### PR TITLE
[#43] 사용자 프로필 정보 조회 기능

### DIFF
--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedReqDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/PostFeedReqDto.java
@@ -3,12 +3,11 @@ package inha.capstone.fooda.domain.feed.dto;
 import inha.capstone.fooda.domain.feed.entity.Menu;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/inha/capstone/fooda/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/repository/FeedRepository.java
@@ -1,19 +1,21 @@
 package inha.capstone.fooda.domain.feed.repository;
 
 import inha.capstone.fooda.domain.feed.entity.Feed;
-import inha.capstone.fooda.domain.friend.entity.Friend;
 import inha.capstone.fooda.domain.member.entity.Member;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     @EntityGraph(attributePaths = {"foods", "feedImages"})
     @Query("SELECT DISTINCT t FROM Feed t WHERE t.createdAt BETWEEN :startDate AND :endDate AND t.member.id = :memberId")
-    public List<Feed> findAllByCreatedAtBetweenAndMemberIdUsingFetchJoin(LocalDateTime startDate, LocalDateTime endDate, Long memberId);
+    public List<Feed> findAllByCreatedAtBetweenAndMemberIdUsingFetchJoin(LocalDateTime startDate, LocalDateTime endDate,
+                                                                         Long memberId);
+
+    public List<Feed> findAllByMember(Member member);
+
+    public Long countAllByMember(Member member);
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
@@ -6,22 +6,21 @@ import inha.capstone.fooda.domain.feed.entity.Feed;
 import inha.capstone.fooda.domain.feed.entity.Menu;
 import inha.capstone.fooda.domain.feed.repository.FeedRepository;
 import inha.capstone.fooda.domain.feed_image.service.FeedImageService;
-import inha.capstone.fooda.domain.food.entity.Food;
 import inha.capstone.fooda.domain.food.repository.FoodRepository;
 import inha.capstone.fooda.domain.food.service.FoodService;
 import inha.capstone.fooda.domain.member.repository.MemberRepository;
 import inha.capstone.fooda.utils.AICommunicationUtils;
 import inha.capstone.fooda.utils.FoodListReqDto;
 import inha.capstone.fooda.utils.FoodListResDto;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -36,7 +35,8 @@ public class FeedService {
     private final AICommunicationUtils aiCommunicationUtils;
 
     @Transactional
-    public UploadFeedDto uploadFeed(Long memberId, Boolean open, Menu menu, List<MultipartFile> imgs) throws IOException {
+    public UploadFeedDto uploadFeed(Long memberId, Boolean open, Menu menu, List<MultipartFile> imgs)
+            throws IOException {
         Long feedId = saveFeed(memberId, open, menu);
         List<FoodListResDto> foodList = new ArrayList<>();
         for (MultipartFile img : imgs) {
@@ -59,9 +59,17 @@ public class FeedService {
     }
 
     public List<FeedDto> selectFeed(Long memberId, LocalDate start, LocalDate end) {
-        List<Feed> feedList = feedRepository.findAllByCreatedAtBetweenAndMemberIdUsingFetchJoin(start.atStartOfDay(), end.plusDays(1).atStartOfDay(), memberId);
+        List<Feed> feedList = feedRepository.findAllByCreatedAtBetweenAndMemberIdUsingFetchJoin(start.atStartOfDay(),
+                end.plusDays(1).atStartOfDay(), memberId);
         return feedList.stream()
                 .map(FeedDto::from)
                 .toList();
+    }
+
+    public Long countFeed(String username) {
+        return feedRepository.countAllByMember(
+                memberRepository.findByUsername(username)
+                        .orElseThrow(() -> new UsernameNotFoundException(username + " 아이디를 가진 유저가 존재하지 않습니다."))
+        );
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed_image/repository/FeedImageRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed_image/repository/FeedImageRepository.java
@@ -5,5 +5,5 @@ import inha.capstone.fooda.domain.feed_image.entity.FeedImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedImageRepository extends JpaRepository<FeedImage, Long> {
-
+    public FeedImage findTop1ByFeed(Feed feed);
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
@@ -2,22 +2,24 @@ package inha.capstone.fooda.domain.feed_image.service;
 
 import inha.capstone.fooda.domain.common.service.S3Service;
 import inha.capstone.fooda.domain.feed.entity.Feed;
-import inha.capstone.fooda.domain.feed.entity.Menu;
 import inha.capstone.fooda.domain.feed.repository.FeedRepository;
+import inha.capstone.fooda.domain.feed_image.dto.FeedImageDto;
 import inha.capstone.fooda.domain.feed_image.entity.FeedImage;
 import inha.capstone.fooda.domain.feed_image.exception.NotImageFileExcpetion;
 import inha.capstone.fooda.domain.feed_image.repository.FeedImageRepository;
 import inha.capstone.fooda.domain.member.entity.Member;
+import inha.capstone.fooda.domain.member.repository.MemberRepository;
+import java.awt.Image;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.imageio.ImageIO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import javax.imageio.ImageIO;
-import java.awt.*;
-import java.io.IOException;
-import java.util.List;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +27,7 @@ import java.util.UUID;
 public class FeedImageService {
     private final FeedImageRepository feedImageRepository;
     private final FeedRepository feedRepository;
+    private final MemberRepository memberRepository;
     private final S3Service s3Service;
 
     @Transactional
@@ -32,7 +35,9 @@ public class FeedImageService {
 
         // 이미지 파일인지 검사하는 로직
         Image image = ImageIO.read(img.getInputStream());
-        if (image == null) throw new NotImageFileExcpetion();
+        if (image == null) {
+            throw new NotImageFileExcpetion();
+        }
 
         String fileName = UUID.randomUUID().toString();
         String url = s3Service.upload(img, fileName);
@@ -44,5 +49,34 @@ public class FeedImageService {
                 .build();
         feedImageRepository.save(feedImage);
         return url;
+    }
+
+    /**
+     * TODO 작동하는지 확인 (테스트 메소드 안적음)
+     * 사용자가 업로드한 피드의 첫번째 이미지 리스트를 조회한다.
+     *
+     * @param username 사용자의 닉네임(아이디)
+     * @return 피드 첫번째 이미지 리스트
+     */
+    public List<FeedImageDto> getFirstFeedImageList(String username) {
+        // 멤버 조회
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException(username + " 아이디를 가진 유저가 존재하지 않습니다."));
+
+        // 해당 멤버가 올린 피드 조회
+        List<Feed> feedList = feedRepository.findAllByMember(member);
+
+        // TODO 리팩토링
+        // 피드의 첫번째 이미지 리스트
+        List<FeedImage> feedImageList = new ArrayList<>();
+        for (Feed feed : feedList) {
+            // 피드에 해당하는 제일 첫번째 피드 이미지 조회
+            FeedImage feedImage = feedImageRepository.findTop1ByFeed(feed);
+            feedImageList.add(feedImage);
+        }
+
+        return feedImageList.stream()
+                .map(FeedImageDto::from)
+                .toList();
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed_image/service/FeedImageService.java
@@ -11,7 +11,6 @@ import inha.capstone.fooda.domain.member.entity.Member;
 import inha.capstone.fooda.domain.member.repository.MemberRepository;
 import java.awt.Image;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import javax.imageio.ImageIO;
@@ -52,7 +51,6 @@ public class FeedImageService {
     }
 
     /**
-     * TODO 작동하는지 확인 (테스트 메소드 안적음)
      * 사용자가 업로드한 피드의 첫번째 이미지 리스트를 조회한다.
      *
      * @param username 사용자의 닉네임(아이디)
@@ -66,14 +64,10 @@ public class FeedImageService {
         // 해당 멤버가 올린 피드 조회
         List<Feed> feedList = feedRepository.findAllByMember(member);
 
-        // TODO 리팩토링
         // 피드의 첫번째 이미지 리스트
-        List<FeedImage> feedImageList = new ArrayList<>();
-        for (Feed feed : feedList) {
-            // 피드에 해당하는 제일 첫번째 피드 이미지 조회
-            FeedImage feedImage = feedImageRepository.findTop1ByFeed(feed);
-            feedImageList.add(feedImage);
-        }
+        List<FeedImage> feedImageList = feedList.stream()
+                .map(feedImageRepository::findTop1ByFeed)
+                .toList();
 
         return feedImageList.stream()
                 .map(FeedImageDto::from)

--- a/src/main/java/inha/capstone/fooda/domain/food/dto/PostFoodReqDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/dto/PostFoodReqDto.java
@@ -19,6 +19,5 @@ public class PostFoodReqDto {
     @Schema(example = "3", description = "업데이트 할 피드의 Id")
     private Long feedId;
 
-    @Schema(example = "[{\"no\":1,\"name\":\"Pizza\",\"size\":200,\"energy\":250.5,\"protein\":10.2,\"province\":5.5,\"carbohydrate\":30.0,\"calcium\":50.2,\"salt\":1.5}, {\"no\":2,\"name\":\"Burger\",\"size\":150,\"energy\":300.0,\"protein\":12.5,\"province\":6.0,\"carbohydrate\":25.0,\"calcium\":40.5,\"salt\":1.8}]", description = "이미지에서 추출된 음식 목록")
     List<FoodListResDto> foodList;
 }

--- a/src/main/java/inha/capstone/fooda/domain/food/entity/Food.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/entity/Food.java
@@ -2,17 +2,21 @@ package inha.capstone.fooda.domain.food.entity;
 
 import inha.capstone.fooda.domain.common.entity.BaseEntity;
 import inha.capstone.fooda.domain.feed.entity.Feed;
-import inha.capstone.fooda.domain.member.dto.GetFindProfileInfoMemberResDto;
-import inha.capstone.fooda.domain.member.dto.MemberDto;
 import inha.capstone.fooda.utils.FoodListResDto;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.math.BigDecimal;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.math.BigDecimal;
-import java.util.Objects;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -51,8 +55,12 @@ public class Food extends BaseEntity {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Food)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Food)) {
+            return false;
+        }
         Food that = (Food) o;
         return this.getId() != null && this.getId().equals(that.getId());
     }
@@ -63,7 +71,8 @@ public class Food extends BaseEntity {
     }
 
     @Builder
-    public Food(Long id, Feed feed, String foodName, BigDecimal energy, BigDecimal carbs, BigDecimal protein, BigDecimal fat, BigDecimal calcium, BigDecimal salt) {
+    public Food(Long id, Feed feed, String foodName, BigDecimal energy, BigDecimal carbs, BigDecimal protein,
+                BigDecimal fat, BigDecimal calcium, BigDecimal salt) {
         this.id = id;
         this.feed = feed;
         this.foodName = foodName;

--- a/src/main/java/inha/capstone/fooda/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/friend/repository/FriendRepository.java
@@ -2,12 +2,15 @@ package inha.capstone.fooda.domain.friend.repository;
 
 import inha.capstone.fooda.domain.friend.entity.Friend;
 import inha.capstone.fooda.domain.member.entity.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
+    long countAllByFollowing(Member member);
+
+    long countAllByFollower(Member member);
+
     List<Friend> findByFollowing(Member member);
 
     List<Friend> findByFollower(Member member);

--- a/src/main/java/inha/capstone/fooda/domain/friend/service/FriendService.java
+++ b/src/main/java/inha/capstone/fooda/domain/friend/service/FriendService.java
@@ -6,12 +6,11 @@ import inha.capstone.fooda.domain.friend.repository.FriendRepository;
 import inha.capstone.fooda.domain.member.dto.MemberDto;
 import inha.capstone.fooda.domain.member.entity.Member;
 import inha.capstone.fooda.domain.member.repository.MemberRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +18,26 @@ import java.util.List;
 public class FriendService {
     private final FriendRepository friendRepository;
     private final MemberRepository memberRepository;
+
+    /**
+     * 아이디가 username인 사용자가 팔로잉 수 조회
+     *
+     * @param username 조회하려는 사용자의 아이디
+     * @return 팔로잉 수
+     */
+    public long findFollowingMemberCount(String username) {
+        return friendRepository.countAllByFollower(findMemberByUsername(username));
+    }
+
+    /**
+     * 아이디가 username인 사용자의 팔로워 수 조회
+     *
+     * @param username 조회하려는 사용자의 아이디
+     * @return 팔로워 수
+     */
+    public long findFollowerMemberCount(String username) {
+        return friendRepository.countAllByFollowing(findMemberByUsername(username));
+    }
 
     /**
      * 아이디가 username인 사용자가 팔로우하고 있는 사용자 목록 조회

--- a/src/main/java/inha/capstone/fooda/domain/member/controller/MemberController.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/controller/MemberController.java
@@ -37,7 +37,6 @@ public class MemberController {
     private final FeedImageService feedImageService;
     private final FriendService friendService;
 
-    // TODO 작동 테스트
     @Operation(
             summary = "사용자 프로필 화면 정보 조회 API",
             description = "<p>로그인한 사용자의 프로필 화면의 정보를 조회합니다.</p>"

--- a/src/main/java/inha/capstone/fooda/domain/member/controller/MemberController.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/controller/MemberController.java
@@ -1,6 +1,11 @@
 package inha.capstone.fooda.domain.member.controller;
 
 import inha.capstone.fooda.domain.common.response.DataResponse;
+import inha.capstone.fooda.domain.feed.service.FeedService;
+import inha.capstone.fooda.domain.feed_image.dto.FeedImageDto;
+import inha.capstone.fooda.domain.feed_image.service.FeedImageService;
+import inha.capstone.fooda.domain.friend.service.FriendService;
+import inha.capstone.fooda.domain.member.dto.GetFindInfoMemberResDto;
 import inha.capstone.fooda.domain.member.dto.GetFindProfileInfoMemberResDto;
 import inha.capstone.fooda.domain.member.dto.MemberDto;
 import inha.capstone.fooda.domain.member.dto.PostModifyInfoMemberReqDto;
@@ -10,12 +15,17 @@ import inha.capstone.fooda.security.FoodaPrinciple;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Member")
 @RequiredArgsConstructor
@@ -23,18 +33,49 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class MemberController {
     private final MemberService memberService;
+    private final FeedService feedService;
+    private final FeedImageService feedImageService;
+    private final FriendService friendService;
+
+    // TODO 작동 테스트
+    @Operation(
+            summary = "사용자 프로필 화면 정보 조회 API",
+            description = "<p>로그인한 사용자의 프로필 화면의 정보를 조회합니다.</p>"
+    )
+    @GetMapping(value = "/profile")
+    public ResponseEntity<DataResponse<GetFindProfileInfoMemberResDto>> findProfileInfo(
+            @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle
+    ) {
+        MemberDto memberDto = memberService.findMemberByUsername(principle.getUsername());
+        Long feedCount = feedService.countFeed(principle.getUsername());
+        Long followerMemberCount = friendService.findFollowerMemberCount(principle.getUsername());
+        Long followingMemberCount = friendService.findFollowingMemberCount(principle.getUsername());
+        List<FeedImageDto> feedImageList = feedImageService.getFirstFeedImageList(principle.getUsername());
+
+        GetFindProfileInfoMemberResDto response = GetFindProfileInfoMemberResDto.from(
+                memberDto.getName(),
+                feedCount,
+                followerMemberCount,
+                followingMemberCount,
+                feedImageList);
+
+        return new ResponseEntity<>(
+                new DataResponse<>(response),
+                HttpStatus.OK
+        );
+    }
 
     @Operation(
             summary = "사용자 프로필 편집 화면 정보 조회 API",
             description = "<p>로그인한 사용자의 프로필 편집 화면의 정보를 조회합니다.</p>"
     )
     @GetMapping(value = "/profile/settings")
-    public ResponseEntity<DataResponse<GetFindProfileInfoMemberResDto>> findInfo(
+    public ResponseEntity<DataResponse<GetFindInfoMemberResDto>> findInfo(
             @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle
     ) {
         MemberDto memberDto = memberService.findMemberByUsername(principle.getUsername());
 
-        GetFindProfileInfoMemberResDto response = GetFindProfileInfoMemberResDto.from(memberDto);
+        GetFindInfoMemberResDto response = GetFindInfoMemberResDto.from(memberDto);
 
         return new ResponseEntity<>(
                 new DataResponse<>(response),
@@ -51,7 +92,8 @@ public class MemberController {
             @Validated @RequestBody PostModifyInfoMemberReqDto postModifyInfoMemberReqDto,
             @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle
     ) {
-        MemberDto memberDto = memberService.modifyMemberByUsername(principle.getUsername(), postModifyInfoMemberReqDto.toDto());
+        MemberDto memberDto = memberService.modifyMemberByUsername(principle.getUsername(),
+                postModifyInfoMemberReqDto.toDto());
 
         PostModifyInfoMemberResDto response = PostModifyInfoMemberResDto.from(memberDto);
 

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/GetFindInfoMemberResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/GetFindInfoMemberResDto.java
@@ -1,0 +1,48 @@
+package inha.capstone.fooda.domain.member.dto;
+
+import inha.capstone.fooda.domain.member.entity.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetFindInfoMemberResDto {
+    @Schema(example = "홍길동", description = "사용자의 실명")
+    private String name;
+
+    @Schema(example = "gildong", description = "사용자의 아이디(닉네임)")
+    private String username;
+
+    @Schema(example = "MALE", description = "성별")
+    private Gender gender;
+
+    @Schema(example = "70", description = "몸무게")
+    private Integer weight;
+
+    @Schema(example = "180", description = "키")
+    private Integer height;
+
+    @Schema(example = "25", description = "나이")
+    private Integer age;
+
+    @Schema(example = "65", description = "목표몸무게")
+    private Integer targetWeight;
+
+    @Schema(example = "2000", description = "목표칼로리")
+    private Integer targetKcal;
+
+    public static GetFindInfoMemberResDto from(MemberDto memberDto) {
+        return new GetFindInfoMemberResDto(
+                memberDto.getName(),
+                memberDto.getUsername(),
+                memberDto.getGender(),
+                memberDto.getWeight(),
+                memberDto.getHeight(),
+                memberDto.getAge(),
+                memberDto.getTargetWeight(),
+                memberDto.getTargetKcal()
+        );
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/GetFindProfileInfoMemberResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/GetFindProfileInfoMemberResDto.java
@@ -1,6 +1,7 @@
 package inha.capstone.fooda.domain.member.dto;
 
 import inha.capstone.fooda.domain.feed_image.dto.FeedImageDto;
+import inha.capstone.fooda.utils.FeedImageResDto;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,8 +18,7 @@ public class GetFindProfileInfoMemberResDto {
 
     Long followingCount;
 
-    // TODO 여기 DTO 변경
-    List<FeedImageDto> feedImageList;
+    List<FeedImageResDto> feedImageList;
 
     public static GetFindProfileInfoMemberResDto from(
             String name,
@@ -26,6 +26,14 @@ public class GetFindProfileInfoMemberResDto {
             Long followerCount,
             Long followingCount,
             List<FeedImageDto> feedImageList) {
-        return new GetFindProfileInfoMemberResDto(name, feedCount, followerCount, followingCount, feedImageList);
+        return new GetFindProfileInfoMemberResDto(
+                name,
+                feedCount,
+                followerCount,
+                followingCount,
+                feedImageList
+                        .stream()
+                        .map(FeedImageResDto::from)
+                        .toList());
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/GetFindProfileInfoMemberResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/GetFindProfileInfoMemberResDto.java
@@ -1,7 +1,7 @@
 package inha.capstone.fooda.domain.member.dto;
 
-import inha.capstone.fooda.domain.member.entity.Gender;
-import io.swagger.v3.oas.annotations.media.Schema;
+import inha.capstone.fooda.domain.feed_image.dto.FeedImageDto;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,40 +9,24 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetFindProfileInfoMemberResDto {
-    @Schema(example = "홍길동", description = "사용자의 실명")
-    private String name;
+    String name;
 
-    @Schema(example = "gildong", description = "사용자의 아이디(닉네임)")
-    private String username;
+    Long feedCount;
 
-    @Schema(example = "MALE", description = "성별")
-    private Gender gender;
+    Long followerCount;
 
-    @Schema(example = "70", description = "몸무게")
-    private Integer weight;
+    Long followingCount;
 
-    @Schema(example = "180", description = "키")
-    private Integer height;
+    // TODO 여기 DTO 변경
+    List<FeedImageDto> feedImageList;
 
-    @Schema(example = "25", description = "나이")
-    private Integer age;
-
-    @Schema(example = "65", description = "목표몸무게")
-    private Integer targetWeight;
-
-    @Schema(example = "2000", description = "목표칼로리")
-    private Integer targetKcal;
-
-    public static GetFindProfileInfoMemberResDto from(MemberDto memberDto) {
-        return new GetFindProfileInfoMemberResDto(
-                memberDto.getName(),
-                memberDto.getUsername(),
-                memberDto.getGender(),
-                memberDto.getWeight(),
-                memberDto.getHeight(),
-                memberDto.getAge(),
-                memberDto.getTargetWeight(),
-                memberDto.getTargetKcal()
-        );
+    // TODO from 메소드 정의
+    public static GetFindProfileInfoMemberResDto from(
+            String name,
+            Long feedCount,
+            Long followerCount,
+            Long followingCount,
+            List<FeedImageDto> feedImageList) {
+        return new GetFindProfileInfoMemberResDto(name, feedCount, followerCount, followingCount, feedImageList);
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/member/dto/GetFindProfileInfoMemberResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/dto/GetFindProfileInfoMemberResDto.java
@@ -20,7 +20,6 @@ public class GetFindProfileInfoMemberResDto {
     // TODO 여기 DTO 변경
     List<FeedImageDto> feedImageList;
 
-    // TODO from 메소드 정의
     public static GetFindProfileInfoMemberResDto from(
             String name,
             Long feedCount,

--- a/src/main/java/inha/capstone/fooda/domain/member/service/MemberService.java
+++ b/src/main/java/inha/capstone/fooda/domain/member/service/MemberService.java
@@ -1,5 +1,8 @@
 package inha.capstone.fooda.domain.member.service;
 
+import inha.capstone.fooda.domain.feed.repository.FeedRepository;
+import inha.capstone.fooda.domain.feed_image.repository.FeedImageRepository;
+import inha.capstone.fooda.domain.friend.service.FriendService;
 import inha.capstone.fooda.domain.member.dto.MemberDto;
 import inha.capstone.fooda.domain.member.entity.Member;
 import inha.capstone.fooda.domain.member.repository.MemberRepository;
@@ -12,7 +15,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberService {
+    private final FriendService friendService;
     private final MemberRepository memberRepository;
+    private final FeedRepository feedRepository;
+    private final FeedImageRepository feedImageRepository;
 
     /**
      * 유저네임(아이디)로 멤버 조회

--- a/src/main/java/inha/capstone/fooda/utils/FeedImageResDto.java
+++ b/src/main/java/inha/capstone/fooda/utils/FeedImageResDto.java
@@ -1,0 +1,21 @@
+package inha.capstone.fooda.utils;
+
+import inha.capstone.fooda.domain.feed_image.dto.FeedImageDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FeedImageResDto {
+    @Schema(example = "3", description = "피드 이미지 ID")
+    private Long id;
+
+    @Schema(example = "3", description = "피드 이미지 URL")
+    private String url;
+
+    public static FeedImageResDto from(FeedImageDto feedImageDto) {
+        return new FeedImageResDto(feedImageDto.getId(), feedImageDto.getUrl());
+    }
+}

--- a/src/main/java/inha/capstone/fooda/utils/FoodListResDto.java
+++ b/src/main/java/inha/capstone/fooda/utils/FoodListResDto.java
@@ -1,24 +1,31 @@
 package inha.capstone.fooda.utils;
 
 import inha.capstone.fooda.domain.food.entity.Food;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.math.BigDecimal;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @Setter
 public class FoodListResDto {
+    @Schema(example = "Pizza", description = "음식 이름")
     private String name;
+    @Schema(example = "980", description = "칼로리")
     private BigDecimal energy;
+    @Schema(example = "9.4", description = "단백질")
     private BigDecimal protein;
+    @Schema(example = "3.4", description = "지방")
     private BigDecimal fat;
+    @Schema(example = "14.9", description = "탄수화물")
     private BigDecimal carbs;
+    @Schema(example = "3", description = "칼슘")
     private BigDecimal calcium;
+    @Schema(example = "6", description = "나트륨")
     private BigDecimal salt;
 
     public static FoodListResDto from(Food food) {


### PR DESCRIPTION
### 관련 이슈
- #43 

### 작업 사항
- 사용자 프로필 정보 조회 기능

### 첨부
<img width="822" alt="image" src="https://github.com/pix-el-wave/fooda-backend/assets/62539341/7a5063f2-04aa-468b-9ffd-d7ead2bfb5cc">

### 특이사항
- 음식 목록 기록 API에서 스웨거 명세 잘못되어있는 것 변경
<img width="538" alt="image" src="https://github.com/pix-el-wave/fooda-backend/assets/62539341/cfc4dbb8-0b4b-43a4-9a71-9b464cadbd2f">
<img width="470" alt="image" src="https://github.com/pix-el-wave/fooda-backend/assets/62539341/c05c74ae-0cde-45f8-8348-516ce4b2b18a">
