### PR TITLE
[ #37 ] 팔로우 하는 사람들의 피드 기록 확인 API

### DIFF
--- a/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/controller/FeedController.java
@@ -13,10 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -58,6 +55,21 @@ public class FeedController {
 
         return new ResponseEntity<>(
                 new DataResponse<>(new PostSelectFeedResDto(feedDtoList)),
+                HttpStatus.OK
+        );
+    }
+
+    @Operation(
+            summary = "피드 조회 API",
+            description = "<p>피드을 조회합니다.</p>"
+    )
+    @GetMapping("/list/following")
+    public ResponseEntity<DataResponse<GetSelectFeedFollowingResDto>> selectFeedFollowing(
+            @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle
+    ) throws IOException {
+        List<FeedDto> feedDtoList = feedService.selectFeedByFollowing(principle.getMemberId());
+        return new ResponseEntity<>(
+                new DataResponse<>(new GetSelectFeedFollowingResDto(feedDtoList)),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/FeedDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/FeedDto.java
@@ -22,6 +22,12 @@ public class FeedDto {
     @Schema(example = "26", description = "좋아요 수")
     private Long likeCount;
 
+    @Schema(description = "피드 작성자 별명")
+    private String name;
+
+    @Schema(description = "피드 작성자 ID")
+    private String username;
+
     @Schema(description = "생성 날짜")
     private LocalDateTime createdAt;
 
@@ -32,10 +38,12 @@ public class FeedDto {
     private List<FeedImageDto> feedImages;
 
     @Builder
-    public FeedDto(Long id, Long likeCount, LocalDateTime createdAt, List<FoodListResDto> foods, List<FeedImageDto> feedImages) {
+    public FeedDto(Long id, Long likeCount, String name, String username, LocalDateTime createdAt, List<FoodListResDto> foods, List<FeedImageDto> feedImages) {
         this.id = id;
         this.likeCount = likeCount;
         this.createdAt = createdAt;
+        this.name = name;
+        this.username = username;
         this.foods = foods;
         this.feedImages = feedImages;
     }
@@ -50,6 +58,8 @@ public class FeedDto {
                 .feedImages(feed.getFeedImages().stream()
                         .map(FeedImageDto::from)
                         .toList())
+                .name(feed.getMember().getName())
+                .username(feed.getMember().getUsername())
                 .likeCount(feed.getLikeCount())
                 .build();
     }

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/FeedDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/FeedDto.java
@@ -22,10 +22,10 @@ public class FeedDto {
     @Schema(example = "26", description = "좋아요 수")
     private Long likeCount;
 
-    @Schema(description = "피드 작성자 별명")
+    @Schema(description = "피드 작성자 이름")
     private String name;
 
-    @Schema(description = "피드 작성자 ID")
+    @Schema(description = "피드 작성자 닉네임")
     private String username;
 
     @Schema(description = "생성 날짜")

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/GetSelectFeedFollowingResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/GetSelectFeedFollowingResDto.java
@@ -1,0 +1,18 @@
+package inha.capstone.fooda.domain.feed.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@NoArgsConstructor
+public class GetSelectFeedFollowingResDto {
+
+    @Schema(description = "피드에 포함된 음식 목록")
+    List<FeedDto> feedDtoList;
+}

--- a/src/main/java/inha/capstone/fooda/domain/feed/dto/PostSelectFeedReqDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/dto/PostSelectFeedReqDto.java
@@ -1,18 +1,15 @@
 package inha.capstone.fooda.domain.feed.dto;
 
-import inha.capstone.fooda.domain.feed.entity.Menu;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import org.springframework.web.multipart.MultipartFile;
+import lombok.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Getter
+@Setter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class PostSelectFeedReqDto {
 
     @NotNull(message = "시작 날짜를 정해주세요.")

--- a/src/main/java/inha/capstone/fooda/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/repository/FeedRepository.java
@@ -6,6 +6,7 @@ import inha.capstone.fooda.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,9 +16,9 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     @EntityGraph(attributePaths = {"foods", "feedImages", "member"})
     @Query("SELECT DISTINCT t FROM Feed t WHERE t.createdAt BETWEEN :startDate AND :endDate AND t.member.id = :memberId")
-    public List<Feed> findAllByCreatedAtBetweenAndMemberIdUsingFetchJoin(LocalDateTime startDate, LocalDateTime endDate, Long memberId);
+    public List<Feed> findAllByCreatedAtBetweenAndMemberIdUsingFetchJoin(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, @Param("memberId") Long memberId);
 
     @EntityGraph(attributePaths = {"foods", "feedImages", "member"})
     @Query("SELECT DISTINCT t FROM Feed t WHERE t.member.id = :memberId OR t.member.id IN (SELECT f.follower.id FROM Friend f WHERE f.following.id = :memberId)")
-    public List<Feed> findFeedsByFollowing(Long memberId);
+    public List<Feed> findFeedsByFollowing(@Param("memberId") Long memberId);
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/repository/FeedRepository.java
@@ -16,4 +16,8 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     @EntityGraph(attributePaths = {"foods", "feedImages", "member"})
     @Query("SELECT DISTINCT t FROM Feed t WHERE t.createdAt BETWEEN :startDate AND :endDate AND t.member.id = :memberId")
     public List<Feed> findAllByCreatedAtBetweenAndMemberIdUsingFetchJoin(LocalDateTime startDate, LocalDateTime endDate, Long memberId);
+
+    @EntityGraph(attributePaths = {"foods", "feedImages", "member"})
+    @Query("SELECT DISTINCT t FROM Feed t WHERE t.member.id = :memberId OR t.member.id IN (SELECT f.follower.id FROM Friend f WHERE f.following.id = :memberId)")
+    public List<Feed> findFeedsByFollowing(Long memberId);
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/repository/FeedRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 
-    @EntityGraph(attributePaths = {"foods", "feedImages"})
+    @EntityGraph(attributePaths = {"foods", "feedImages", "member"})
     @Query("SELECT DISTINCT t FROM Feed t WHERE t.createdAt BETWEEN :startDate AND :endDate AND t.member.id = :memberId")
     public List<Feed> findAllByCreatedAtBetweenAndMemberIdUsingFetchJoin(LocalDateTime startDate, LocalDateTime endDate, Long memberId);
 }

--- a/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
+++ b/src/main/java/inha/capstone/fooda/domain/feed/service/FeedService.java
@@ -64,4 +64,11 @@ public class FeedService {
                 .map(FeedDto::from)
                 .toList();
     }
+
+    public List<FeedDto> selectFeedByFollowing(Long memberId) {
+        List<Feed> feedList = feedRepository.findFeedsByFollowing(memberId);
+        return feedList.stream()
+                .map(FeedDto::from)
+                .toList();
+    }
 }


### PR DESCRIPTION
### 관련 이슈
- #37 

### 작업 사항
- 팔로우 하는 사람들의 피드 기록 확인 API

### 첨부
- 1이 2를 언팔로우 상태고 2만 피드가 있을 때 1의 피드 목록
- <img width="196" alt="image" src="https://github.com/pix-el-wave/fooda-backend/assets/76799354/835df822-9fae-42b7-98de-4507f17e0ffc">
- 1이 2를 팔로우 했을 때
- <img width="312" alt="image" src="https://github.com/pix-el-wave/fooda-backend/assets/76799354/238fb1f8-4c98-405c-b2ec-5adbab49e7aa">

### 특이사항
- 갑자기 Param 어노테이션을 써야 JPA에서 인식하길래 사용
- LocalDate로 사용자 입력값에서 변환이 안되길래 ReqDto에 NoArgsConstructor 어노테이션 추가