### PR TITLE
[ #58 ] 구현 태스크 관련 요약

### DIFF
--- a/src/main/java/inha/capstone/fooda/domain/food/controller/FoodController.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/controller/FoodController.java
@@ -1,10 +1,7 @@
 package inha.capstone.fooda.domain.food.controller;
 
 import inha.capstone.fooda.domain.common.response.DataResponse;
-import inha.capstone.fooda.domain.food.dto.PostAnalyzeReqDto;
-import inha.capstone.fooda.domain.food.dto.PostAnalyzeResDto;
-import inha.capstone.fooda.domain.food.dto.PostFoodReqDto;
-import inha.capstone.fooda.domain.food.dto.PostFoodResDto;
+import inha.capstone.fooda.domain.food.dto.*;
 import inha.capstone.fooda.domain.food.service.FoodService;
 import inha.capstone.fooda.security.FoodaPrinciple;
 import inha.capstone.fooda.utils.FoodAnalyzeResDto;
@@ -19,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 
 @Tag(name = "Food")
 @RequiredArgsConstructor
@@ -57,6 +55,23 @@ public class FoodController {
 
         return new ResponseEntity<>(
                 new DataResponse<>(new PostAnalyzeResDto(analyze)),
+                HttpStatus.OK
+        );
+    }
+
+    @Operation(
+            summary = "영양소 점수 API",
+            description = "<p>영양소 섭취량에 따른 점수를 제공합니다.</p>"
+    )
+    @PostMapping("/score")
+    public ResponseEntity<DataResponse<PostScoreResDto>> score(
+            @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle,
+            @Valid @RequestBody PostScoreReqDto postAnalyzeReqDto
+    ) throws IOException {
+        BigDecimal score = foodService.score(principle.getMemberId(), postAnalyzeReqDto.getDate());
+
+        return new ResponseEntity<>(
+                new DataResponse<>(new PostScoreResDto(score)),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/inha/capstone/fooda/domain/food/controller/FoodController.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/controller/FoodController.java
@@ -1,10 +1,13 @@
 package inha.capstone.fooda.domain.food.controller;
 
 import inha.capstone.fooda.domain.common.response.DataResponse;
+import inha.capstone.fooda.domain.food.dto.PostAnalyzeReqDto;
+import inha.capstone.fooda.domain.food.dto.PostAnalyzeResDto;
 import inha.capstone.fooda.domain.food.dto.PostFoodReqDto;
 import inha.capstone.fooda.domain.food.dto.PostFoodResDto;
 import inha.capstone.fooda.domain.food.service.FoodService;
 import inha.capstone.fooda.security.FoodaPrinciple;
+import inha.capstone.fooda.utils.FoodAnalyzeResDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,10 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
@@ -40,6 +40,23 @@ public class FoodController {
 
         return new ResponseEntity<>(
                 new DataResponse<>(new PostFoodResDto(true)),
+                HttpStatus.OK
+        );
+    }
+
+    @Operation(
+            summary = "일일 영양소 분석 API",
+            description = "<p>영양소 섭취량과 기준치를 분석하여 제공합니다.</p>"
+    )
+    @PostMapping("/analyze")
+    public ResponseEntity<DataResponse<PostAnalyzeResDto>> analyze(
+            @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle,
+            @Valid @RequestBody PostAnalyzeReqDto postAnalyzeReqDto
+    ) throws IOException {
+        String analyze = foodService.analyzeFood(principle.getMemberId(), postAnalyzeReqDto.getDate());
+
+        return new ResponseEntity<>(
+                new DataResponse<>(new PostAnalyzeResDto(analyze)),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/inha/capstone/fooda/domain/food/dto/NutrientDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/dto/NutrientDto.java
@@ -1,0 +1,30 @@
+package inha.capstone.fooda.domain.food.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+@Getter
+public class NutrientDto {
+    private BigDecimal calcium;
+    private BigDecimal carbs;
+    private BigDecimal energy;
+    private BigDecimal fat;
+    private BigDecimal protein;
+    private BigDecimal salt;
+
+    public NutrientDto(BigDecimal calcium, BigDecimal carbs, BigDecimal energy, BigDecimal fat, BigDecimal protein, BigDecimal salt) {
+        this.calcium = Optional.ofNullable(calcium).orElse(BigDecimal.ZERO);
+        this.carbs = Optional.ofNullable(carbs).orElse(BigDecimal.ZERO);
+        this.energy = Optional.ofNullable(energy).orElse(BigDecimal.ZERO);
+        this.fat = Optional.ofNullable(fat).orElse(BigDecimal.ZERO);
+        this.protein = Optional.ofNullable(protein).orElse(BigDecimal.ZERO);
+        this.salt = Optional.ofNullable(salt).orElse(BigDecimal.ZERO);
+    }
+    public static NutrientDto baseNutrient() {
+        return new NutrientDto(new BigDecimal("700.0"), new BigDecimal("324.0"), new BigDecimal("1800.0"), new BigDecimal("54.0"), new BigDecimal("55.0"), new BigDecimal("2000.0"));
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/food/dto/PostAnalyzeReqDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/dto/PostAnalyzeReqDto.java
@@ -1,0 +1,22 @@
+package inha.capstone.fooda.domain.food.dto;
+
+import inha.capstone.fooda.utils.FoodListResDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostAnalyzeReqDto {
+
+    @NotNull(message = "영양소 분석 날짜를 보내주세요.")
+    @Schema(example = "2020-03-23", description = "영양소 분석할 날짜")
+    private LocalDate date;
+}

--- a/src/main/java/inha/capstone/fooda/domain/food/dto/PostAnalyzeResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/dto/PostAnalyzeResDto.java
@@ -1,0 +1,11 @@
+package inha.capstone.fooda.domain.food.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class PostAnalyzeResDto {
+    private String result;
+}

--- a/src/main/java/inha/capstone/fooda/domain/food/dto/PostScoreReqDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/dto/PostScoreReqDto.java
@@ -1,0 +1,20 @@
+package inha.capstone.fooda.domain.food.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostScoreReqDto {
+
+    @NotNull(message = "영양소 분석 날짜를 보내주세요.")
+    @Schema(example = "2020-03-23", description = "영양소 분석할 날짜")
+    private LocalDate date;
+}

--- a/src/main/java/inha/capstone/fooda/domain/food/dto/PostScoreResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/dto/PostScoreResDto.java
@@ -1,0 +1,13 @@
+package inha.capstone.fooda.domain.food.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class PostScoreResDto {
+    private BigDecimal score;
+}

--- a/src/main/java/inha/capstone/fooda/domain/food/repository/FoodRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/repository/FoodRepository.java
@@ -1,8 +1,27 @@
 package inha.capstone.fooda.domain.food.repository;
 
+import inha.capstone.fooda.domain.feed.entity.Feed;
+import inha.capstone.fooda.domain.food.dto.NutrientDto;
 import inha.capstone.fooda.domain.food.entity.Food;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface FoodRepository extends JpaRepository<Food, Long> {
 
+    @Query(value = "SELECT new inha.capstone.fooda.domain.food.dto.NutrientDto(" +
+            "SUM(f.calcium) as calcium, SUM(f.carbs) as carbs, SUM(f.energy) as energy, " +
+            "SUM(f.fat) as fat, SUM(f.protein) as protein, SUM(f.salt) as salt) " +
+            "FROM Food f " +
+            "LEFT JOIN f.feed feed " +
+            "LEFT JOIN feed.member member " +
+            "WHERE member.id = :memberId " +
+            "AND feed.createdAt BETWEEN :startDate AND :endDate")
+    public NutrientDto findSumOfCalDay(@Param("memberId") Long memberId,
+                                       @Param("startDate") LocalDateTime startDate,
+                                       @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
@@ -12,6 +12,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -36,13 +39,34 @@ public class FoodService {
     }
 
     public String analyzeFood(Long memberId, LocalDate date) throws IOException {
-        String s = date.atStartOfDay().toString();
-        String s2 = date.plusDays(1).atStartOfDay().toString();
         NutrientDto now = foodRepository.findSumOfCalDay(memberId, date.atStartOfDay(), date.plusDays(1).atStartOfDay());
         NutrientDto to = NutrientDto.baseNutrient();
 
         FoodAnalyzeReqDto foodAnalyzeReqDto = FoodAnalyzeReqDto.from(now, to);
 
         return aiCommunicationUtils.requestFoodAnalyze(foodAnalyzeReqDto).getData().getAnalyze();
+    }
+
+    public BigDecimal score(Long memberId, LocalDate date) throws IOException {
+        NutrientDto now = foodRepository.findSumOfCalDay(memberId, date.atStartOfDay(), date.plusDays(1).atStartOfDay());
+        NutrientDto to = NutrientDto.baseNutrient();
+
+
+        BigDecimal score = getScore(now, to);
+
+        return score.setScale(2, RoundingMode.HALF_UP).max(BigDecimal.ZERO);
+    }
+
+    private static BigDecimal getScore(NutrientDto now, NutrientDto to) {
+        BigDecimal calciumDiff = now.getCalcium().subtract(to.getCalcium()).pow(2);
+        BigDecimal carbsDiff = now.getCarbs().subtract(to.getCarbs()).pow(2);
+        BigDecimal energyDiff = now.getEnergy().subtract(to.getEnergy()).pow(2);
+        BigDecimal fatDiff = now.getFat().subtract(to.getFat()).pow(2);
+        BigDecimal proteinDiff = now.getProtein().subtract(to.getProtein()).pow(2);
+        BigDecimal saltDiff = now.getSalt().subtract(to.getSalt()).pow(2);
+
+        BigDecimal sumOfSquares = calciumDiff.add(carbsDiff).add(energyDiff).add(fatDiff).add(proteinDiff).add(saltDiff);
+
+        return BigDecimal.valueOf(100).subtract(BigDecimal.valueOf(0.06435).multiply(sumOfSquares.sqrt(new MathContext(4))));
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
@@ -2,14 +2,18 @@ package inha.capstone.fooda.domain.food.service;
 
 import inha.capstone.fooda.domain.feed.entity.Feed;
 import inha.capstone.fooda.domain.feed.repository.FeedRepository;
+import inha.capstone.fooda.domain.food.dto.NutrientDto;
 import inha.capstone.fooda.domain.food.entity.Food;
 import inha.capstone.fooda.domain.food.repository.FoodRepository;
-import inha.capstone.fooda.utils.FoodListResDto;
+import inha.capstone.fooda.utils.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -18,6 +22,7 @@ import java.util.List;
 public class FoodService {
     private final FoodRepository foodRepository;
     private final FeedRepository feedRepository;
+    private final AICommunicationUtils aiCommunicationUtils;
 
     @Transactional
     public void uploadFood(Long feedId, List<FoodListResDto> foodList) throws IOException {
@@ -28,5 +33,16 @@ public class FoodService {
                 .toList();
 
         foodRepository.saveAll(foods);
+    }
+
+    public String analyzeFood(Long memberId, LocalDate date) throws IOException {
+        String s = date.atStartOfDay().toString();
+        String s2 = date.plusDays(1).atStartOfDay().toString();
+        NutrientDto now = foodRepository.findSumOfCalDay(memberId, date.atStartOfDay(), date.plusDays(1).atStartOfDay());
+        NutrientDto to = NutrientDto.baseNutrient();
+
+        FoodAnalyzeReqDto foodAnalyzeReqDto = FoodAnalyzeReqDto.from(now, to);
+
+        return aiCommunicationUtils.requestFoodAnalyze(foodAnalyzeReqDto).getData().getAnalyze();
     }
 }

--- a/src/main/java/inha/capstone/fooda/utils/AICommunicationUtils.java
+++ b/src/main/java/inha/capstone/fooda/utils/AICommunicationUtils.java
@@ -16,6 +16,7 @@ public class AICommunicationUtils {
     private final WebClient aiCommunicationServerWebClient;
 
     public static final String IMAGE_FOOD_LIST_URI = "/image";
+    public static final String FOOD_ANALYZE_URI = "/analyze";
 
     private <T, R> R sendPostRequestWithBlocking(String uri, T requestBody, ParameterizedTypeReference<R> responseTypeReference) throws WebClientResponseException {
         long startTime = System.currentTimeMillis();
@@ -37,8 +38,13 @@ public class AICommunicationUtils {
         }
     }
 
-    public AIServerBaseResDto<List<FoodListResDto>> requestImageList(FoodListReqDto requestImageListReqDto) throws WebClientResponseException {
+    public AIServerBaseResDto<List<FoodListResDto>> requestImageList(FoodListReqDto foodListReqDto) throws WebClientResponseException {
         ParameterizedTypeReference<AIServerBaseResDto<List<FoodListResDto>>> typeReference = new ParameterizedTypeReference<>() {};
-        return this.sendPostRequestWithBlocking(IMAGE_FOOD_LIST_URI, requestImageListReqDto, typeReference);
+        return this.sendPostRequestWithBlocking(IMAGE_FOOD_LIST_URI, foodListReqDto, typeReference);
+    }
+
+    public AIServerBaseResDto<FoodAnalyzeResDto> requestFoodAnalyze(FoodAnalyzeReqDto foodAnalyzeReqDto) throws WebClientResponseException {
+        ParameterizedTypeReference<AIServerBaseResDto<FoodAnalyzeResDto>> typeReference = new ParameterizedTypeReference<>() {};
+        return this.sendPostRequestWithBlocking(FOOD_ANALYZE_URI, foodAnalyzeReqDto, typeReference);
     }
 }

--- a/src/main/java/inha/capstone/fooda/utils/FoodAnalyzeReqDto.java
+++ b/src/main/java/inha/capstone/fooda/utils/FoodAnalyzeReqDto.java
@@ -1,0 +1,29 @@
+package inha.capstone.fooda.utils;
+
+import inha.capstone.fooda.domain.food.dto.NutrientDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@AllArgsConstructor
+@Getter
+public class FoodAnalyzeReqDto {
+    private BigDecimal calcium0;
+    private BigDecimal carbs0;
+    private BigDecimal energy0;
+    private BigDecimal fat0;
+    private BigDecimal protein0;
+    private BigDecimal salt0;
+    private BigDecimal calcium1;
+    private BigDecimal carbs1;
+    private BigDecimal energy1;
+    private BigDecimal fat1;
+    private BigDecimal protein1;
+    private BigDecimal salt1;
+
+    public static FoodAnalyzeReqDto from(NutrientDto now, NutrientDto to) {
+        return new FoodAnalyzeReqDto(now.getCalcium(), now.getCarbs(), now.getEnergy(), now.getFat(), now.getProtein(), now.getSalt(),
+                                    to.getCalcium(), to.getCarbs(), to.getEnergy(), to.getFat(), to.getProtein(), to.getSalt());
+    }
+}

--- a/src/main/java/inha/capstone/fooda/utils/FoodAnalyzeResDto.java
+++ b/src/main/java/inha/capstone/fooda/utils/FoodAnalyzeResDto.java
@@ -1,0 +1,18 @@
+package inha.capstone.fooda.utils;
+
+import inha.capstone.fooda.domain.food.entity.Food;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class FoodAnalyzeResDto {
+    private String analyze;
+}


### PR DESCRIPTION
### 관련 이슈
- #58 

### 작업 사항
- 일일 영양소 분석 API
- 일일 영양소 점수 계산 API

### 첨부
- <img width="1114" alt="image" src="https://github.com/pix-el-wave/fooda-backend/assets/76799354/232e4bb6-f46d-4ef7-836e-d2df951e0af5">
- <img width="504" alt="image" src="https://github.com/pix-el-wave/fooda-backend/assets/76799354/6d028324-417d-4dfb-a073-3c50cd7a3d8f">

### 특이사항
- 점수 계산 가중치 k를 0.06435로 설정