### PR TITLE
[ #62 ] 음식 목록 기록 시 이전 기록 삭제 및 섭취량 계산 및 영양소 API 추가

### DIFF
--- a/src/main/java/inha/capstone/fooda/domain/common/exception/ExceptionType.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/exception/ExceptionType.java
@@ -4,6 +4,7 @@ import inha.capstone.fooda.domain.auth.exception.JwtUnauthorizedException;
 import inha.capstone.fooda.domain.auth.exception.KakaoOAuthUnauthorizedException;
 import inha.capstone.fooda.domain.feed_image.exception.NotImageFileExcpetion;
 import inha.capstone.fooda.domain.food.exception.MemberNotEqualFeedMemberException;
+import inha.capstone.fooda.domain.food.exception.NotFoundFeedException;
 import inha.capstone.fooda.domain.friend.exception.FriendDuplicateException;
 import inha.capstone.fooda.domain.friend.exception.FriendNotFoundException;
 import inha.capstone.fooda.domain.member.entity.Member;
@@ -51,7 +52,8 @@ public enum ExceptionType {
     FRIEND_DUPLICATE_EXCEPTION(5001, "팔로우 정보가 이미 존재합니다.", FriendDuplicateException.class),
 
     // Food
-    MEMBER_NOT_EQUAL_FEED_MEMBER_EXCEPTION(6000, "피드 작성자가 아닙니다.", MemberNotEqualFeedMemberException.class);
+    MEMBER_NOT_EQUAL_FEED_MEMBER_EXCEPTION(6000, "피드 작성자가 아닙니다.", MemberNotEqualFeedMemberException.class),
+    NOT_FOUND_FEED(6001, "피드를 찾을 수 없습니다.", NotFoundFeedException.class);
 
     private final int errorCode;
     private final String errorMessage;

--- a/src/main/java/inha/capstone/fooda/domain/common/exception/ExceptionType.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/exception/ExceptionType.java
@@ -3,8 +3,10 @@ package inha.capstone.fooda.domain.common.exception;
 import inha.capstone.fooda.domain.auth.exception.JwtUnauthorizedException;
 import inha.capstone.fooda.domain.auth.exception.KakaoOAuthUnauthorizedException;
 import inha.capstone.fooda.domain.feed_image.exception.NotImageFileExcpetion;
+import inha.capstone.fooda.domain.food.exception.MemberNotEqualFeedMemberException;
 import inha.capstone.fooda.domain.friend.exception.FriendDuplicateException;
 import inha.capstone.fooda.domain.friend.exception.FriendNotFoundException;
+import inha.capstone.fooda.domain.member.entity.Member;
 import inha.capstone.fooda.domain.member.exception.UsernameDuplicateException;
 import inha.capstone.fooda.domain.member.exception.UsernameNotFoundExcpetion;
 import java.util.Arrays;
@@ -46,7 +48,10 @@ public enum ExceptionType {
 
     // Friend
     FRIEND_NOT_FOUND_EXCEPTION(5000, "팔로우 정보가 조회되지 않습니다.", FriendNotFoundException.class),
-    FRIEND_DUPLICATE_EXCEPTION(5001, "팔로우 정보가 이미 존재합니다.", FriendDuplicateException.class);
+    FRIEND_DUPLICATE_EXCEPTION(5001, "팔로우 정보가 이미 존재합니다.", FriendDuplicateException.class),
+
+    // Food
+    MEMBER_NOT_EQUAL_FEED_MEMBER_EXCEPTION(6000, "피드 작성자가 아닙니다.", MemberNotEqualFeedMemberException.class);
 
     private final int errorCode;
     private final String errorMessage;

--- a/src/main/java/inha/capstone/fooda/domain/common/response/GlobalExceptionHandler.java
+++ b/src/main/java/inha/capstone/fooda/domain/common/response/GlobalExceptionHandler.java
@@ -47,6 +47,7 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(errorCode, errorMessage));
     }
 
+
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponse> constraintViolationExceptionHandle(ConstraintViolationException e) {
         log.error("ConstraintViolationException: {}", String.valueOf(e));

--- a/src/main/java/inha/capstone/fooda/domain/food/controller/FoodController.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/controller/FoodController.java
@@ -60,6 +60,23 @@ public class FoodController {
     }
 
     @Operation(
+            summary = "그날 먹은 영양소 API",
+            description = "<p>그날 먹은 영양소 섭취량은 반환합니다.</p>"
+    )
+    @PostMapping("/nutrient")
+    public ResponseEntity<DataResponse<PostNutrientResDto>> nutrient(
+            @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle,
+            @Valid @RequestBody PostNutrientReqDto postAnalyzeReqDto
+    ) throws IOException {
+        NutrientDto nutrientDto = foodService.nutrient(principle.getMemberId(), postAnalyzeReqDto.getDate());
+
+        return new ResponseEntity<>(
+                new DataResponse<>(new PostNutrientResDto(nutrientDto)),
+                HttpStatus.OK
+        );
+    }
+
+    @Operation(
             summary = "영양소 점수 API",
             description = "<p>영양소 섭취량에 따른 점수를 제공합니다.</p>"
     )

--- a/src/main/java/inha/capstone/fooda/domain/food/controller/FoodController.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/controller/FoodController.java
@@ -36,7 +36,7 @@ public class FoodController {
             @Parameter(hidden = true) @AuthenticationPrincipal FoodaPrinciple principle,
             @Valid @RequestBody PostFoodReqDto postFoodReqDto
     ) throws IOException {
-        foodService.uploadFood(postFoodReqDto.getFeedId(), postFoodReqDto.getFoodList());
+        foodService.uploadFood(postFoodReqDto.getFeedId(), postFoodReqDto.getFoodList(), principle.getMemberId());
 
         return new ResponseEntity<>(
                 new DataResponse<>(new PostFoodResDto(true)),

--- a/src/main/java/inha/capstone/fooda/domain/food/dto/NutrientDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/dto/NutrientDto.java
@@ -2,12 +2,14 @@ package inha.capstone.fooda.domain.food.dto;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.util.Optional;
 
 @Getter
+@Builder
 public class NutrientDto {
     private BigDecimal calcium;
     private BigDecimal carbs;

--- a/src/main/java/inha/capstone/fooda/domain/food/dto/PostNutrientReqDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/dto/PostNutrientReqDto.java
@@ -1,0 +1,20 @@
+package inha.capstone.fooda.domain.food.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostNutrientReqDto {
+
+    @NotNull(message = "영양소 계산 날짜를 보내주세요.")
+    @Schema(example = "2020-03-23", description = "영양소 분석할 날짜")
+    private LocalDate date;
+}

--- a/src/main/java/inha/capstone/fooda/domain/food/dto/PostNutrientResDto.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/dto/PostNutrientResDto.java
@@ -1,0 +1,11 @@
+package inha.capstone.fooda.domain.food.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class PostNutrientResDto {
+    private NutrientDto nutrient;
+}

--- a/src/main/java/inha/capstone/fooda/domain/food/exception/MemberNotEqualFeedMemberException.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/exception/MemberNotEqualFeedMemberException.java
@@ -1,0 +1,9 @@
+package inha.capstone.fooda.domain.food.exception;
+
+import inha.capstone.fooda.domain.common.exception.ConflictException;
+
+public class MemberNotEqualFeedMemberException extends ConflictException {
+    public MemberNotEqualFeedMemberException(String optionalMessage) {
+        super(optionalMessage);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/food/exception/NotFoundFeedException.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/exception/NotFoundFeedException.java
@@ -1,0 +1,9 @@
+package inha.capstone.fooda.domain.food.exception;
+
+import inha.capstone.fooda.domain.common.exception.ConflictException;
+
+public class NotFoundFeedException extends ConflictException {
+    public NotFoundFeedException(String optionalMessage) {
+        super(optionalMessage);
+    }
+}

--- a/src/main/java/inha/capstone/fooda/domain/food/repository/FoodRepository.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/repository/FoodRepository.java
@@ -2,7 +2,13 @@ package inha.capstone.fooda.domain.food.repository;
 
 import inha.capstone.fooda.domain.food.entity.Food;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.repository.query.Param;
 
 public interface FoodRepository extends JpaRepository<Food, Long> {
 
+    @Modifying
+    @Query("DELETE FROM Food f WHERE f.feed.id = :feedId")
+    void deleteByFeedId(@Param("feedId") Long feedId);
 }

--- a/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
@@ -7,11 +7,15 @@ import inha.capstone.fooda.domain.food.entity.Food;
 import inha.capstone.fooda.domain.food.exception.NotFoundFeedException;
 import inha.capstone.fooda.domain.food.repository.FoodRepository;
 import inha.capstone.fooda.domain.food.exception.MemberNotEqualFeedMemberException;
+import inha.capstone.fooda.domain.member.entity.Gender;
+import inha.capstone.fooda.domain.member.entity.Member;
+import inha.capstone.fooda.domain.member.repository.MemberRepository;
 import inha.capstone.fooda.utils.FoodListResDto;
 import inha.capstone.fooda.utils.*;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +26,7 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +34,7 @@ import java.util.List;
 public class FoodService {
     private final FoodRepository foodRepository;
     private final FeedRepository feedRepository;
+    private final MemberRepository memberRepository;
     private final AICommunicationUtils aiCommunicationUtils;
 
     @Transactional
@@ -51,7 +57,36 @@ public class FoodService {
 
     public String analyzeFood(Long memberId, LocalDate date) throws IOException {
         NutrientDto now = foodRepository.findSumOfCalDay(memberId, date.atStartOfDay(), date.plusDays(1).atStartOfDay());
-        NutrientDto to = NutrientDto.baseNutrient();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new UsernameNotFoundException("유저가 존재하지 않습니다."));
+
+        // 일일 에너지 요구량 계산
+        double bmr = 0;
+        if (member.getGender().equals(Gender.MALE)) {
+            bmr = 10 * member.getWeight() + 6.25 * member.getHeight() - 5 * member.getAge() + 5;
+        } else {
+            bmr = 10 * member.getWeight() + 6.25 * member.getHeight() - 5 * member.getAge() - 161;
+        }
+
+        // 예를 들어, 활동 수준을 중간으로 가정 (1.55)
+        double dailyCalories = bmr * 1.55;
+
+        // 영양소 권장량 계산
+        double protein = member.getWeight() * 0.8; // 단백질: 체중 1kg 당 0.8g
+        double fat = dailyCalories * 0.25 / 9; // 지방: 총 칼로리의 25%
+        double carbs = dailyCalories * 0.5 / 4; // 탄수화물: 총 칼로리의 50%
+        double calcium = 1000; // 칼슘: 일반적으로 1000mg
+        double salt = 6; // 소금: 하루 6g 미만
+
+        NutrientDto to = NutrientDto.builder()
+            .calcium(BigDecimal.valueOf(calcium))
+            .carbs(BigDecimal.valueOf(carbs))
+            .energy(BigDecimal.valueOf(dailyCalories))
+            .fat(BigDecimal.valueOf(fat))
+            .protein(BigDecimal.valueOf(protein))
+            .salt(BigDecimal.valueOf(salt))
+            .build();
 
         FoodAnalyzeReqDto foodAnalyzeReqDto = FoodAnalyzeReqDto.from(now, to);
 

--- a/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
@@ -27,6 +27,7 @@ public class FoodService {
                 .map(dto -> Food.from(feed, dto))
                 .toList();
 
+        foodRepository.deleteByFeedId(feed.getId());
         foodRepository.saveAll(foods);
     }
 }

--- a/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
@@ -55,6 +55,10 @@ public class FoodService {
         }
     }
 
+    public NutrientDto nutrient(Long memberId, LocalDate date) throws IOException {
+        return foodRepository.findSumOfCalDay(memberId, date.atStartOfDay(), date.plusDays(1).atStartOfDay());
+    }
+
     public String analyzeFood(Long memberId, LocalDate date) throws IOException {
         NutrientDto now = foodRepository.findSumOfCalDay(memberId, date.atStartOfDay(), date.plusDays(1).atStartOfDay());
 

--- a/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
+++ b/src/main/java/inha/capstone/fooda/domain/food/service/FoodService.java
@@ -4,6 +4,7 @@ import inha.capstone.fooda.domain.feed.entity.Feed;
 import inha.capstone.fooda.domain.feed.repository.FeedRepository;
 import inha.capstone.fooda.domain.food.entity.Food;
 import inha.capstone.fooda.domain.food.repository.FoodRepository;
+import inha.capstone.fooda.domain.food.exception.MemberNotEqualFeedMemberException;
 import inha.capstone.fooda.utils.FoodListResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,8 +21,12 @@ public class FoodService {
     private final FeedRepository feedRepository;
 
     @Transactional
-    public void uploadFood(Long feedId, List<FoodListResDto> foodList) throws IOException {
+    public void uploadFood(Long feedId, List<FoodListResDto> foodList, Long memberId) throws IOException {
         Feed feed = feedRepository.getReferenceById(feedId);
+
+        if (!feed.getMember().getId().equals(memberId)) {
+            throw new MemberNotEqualFeedMemberException(memberId + "는 피드 작성자 와 달라서 접근할 수 없습니다.");
+        }
 
         List<Food> foods = foodList.stream()
                 .map(dto -> Food.from(feed, dto))


### PR DESCRIPTION
### 관련 이슈
- #62 

### 작업 사항
- 음식 목록 기록 시 이전 기록 삭제
- 사용자의 키, 몸무게, 나이, 성별에 따른 하루 영양 섭취량 계산
- 그날 먹은 영양소 계산 API 추가

### 첨부
- <img width="398" alt="image" src="https://github.com/pix-el-wave/fooda-backend/assets/76799354/1a8b1d42-6d31-4cb7-bd9d-53da08e7f7cf">
